### PR TITLE
Backtrace C# library version 2.0.3 - Unity .NET Framework 4.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 2.0.2 - 28.08.2018
 - Nullable environment variables fix,
 - Fix for invalid database tests that use real minidump files,
-- Fix nullbale GetEnvironmentValue results.
+- Fix nullable GetEnvironmentValue results.
 
 ## Version 2.0.1 - 17.07.2018
 - `BacktraceClient` use reflection to generate better method names for async state machine stack frames,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Backtrace
-[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.1-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.2-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp)
 
-[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.2-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.3-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu/branch/dev?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp/branch/dev)
 
 


### PR DESCRIPTION
## Version 2.0.3 - 04.09.2018
- Thread data condition for Unity on .NET Framework 4.5+