### PR TITLE
Version 2.0.4 

### DIFF
--- a/Backtrace.Tests/Backtrace.Tests.csproj
+++ b/Backtrace.Tests/Backtrace.Tests.csproj
@@ -13,12 +13,6 @@
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="IntegrationTests\Template.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="IntegrationTests\Template.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Backtrace\Backtrace.csproj" />
   </ItemGroup>
 </Project>

--- a/Backtrace.Tests/ClientTests/AggregateExceptionTests.cs
+++ b/Backtrace.Tests/ClientTests/AggregateExceptionTests.cs
@@ -30,7 +30,7 @@ namespace Backtrace.Tests.ClientTests
             _backtraceClient = new BacktraceClient(credentials)
             {
                 BacktraceApi = api.Object,
-                IgnoreAggregateException = true
+                UnpackAggregateExcetpion = true
             };
         }
 

--- a/Backtrace.Tests/ClientTests/AggregateExceptionTests.cs
+++ b/Backtrace.Tests/ClientTests/AggregateExceptionTests.cs
@@ -1,0 +1,70 @@
+﻿using Backtrace.Interfaces;
+using Backtrace.Model;
+using Backtrace.Types;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Backtrace.Tests.ClientTests
+{
+    [TestFixture(
+        Author = "Konrad Dysput",
+        Category = "Client.AggreagateException",
+        Description = "Test client bahaviour for handling aggreagate exceptions")]
+    public class AggregateExceptionTests
+    {
+        protected BacktraceClient _backtraceClient;
+
+        [SetUp]
+        public virtual void Setup()
+        {
+            var api = new Mock<IBacktraceApi>();
+            api.Setup(n => n.Send(It.IsAny<BacktraceData>()))
+                .Returns(new BacktraceResult() { Status = BacktraceResultStatus.Ok });
+
+            api.Setup(n => n.SendAsync(It.IsAny<BacktraceData>()))
+              .ReturnsAsync(() => new BacktraceResult() { Status = BacktraceResultStatus.Ok });
+
+            var credentials = new BacktraceCredentials(@"https://validurl.com/", "validToken");
+            _backtraceClient = new BacktraceClient(credentials)
+            {
+                BacktraceApi = api.Object,
+                IgnoreAggregateException = true
+            };
+        }
+
+        [Test(Description = "Test empty aggregate exception")]
+        public void TestEmptyAggreagateException()
+        {
+            var aggregateException = new AggregateException("test exception");
+            var result = _backtraceClient.Send(aggregateException);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.Status, BacktraceResultStatus.Empty);
+        }
+
+        [Test(Description = "Test default scenario for aggregate exception")]
+        public void TestAggreagateException()
+        {
+            var aggregateException = new AggregateException("test exception",
+                new List<Exception>() {
+                     new ArgumentException("argument exception"),
+                    new InvalidOperationException("invalid operation exception"),
+                    new FormatException("format exception"),
+                });
+            var result = _backtraceClient.Send(aggregateException);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.Status, BacktraceResultStatus.Ok);
+
+            int totalReports = 0;
+            while (result != null)
+            {
+                totalReports++;
+                result = result.InnerExceptionResult;
+            }
+            Assert.AreEqual(3, totalReports);
+
+        }
+    }
+}

--- a/Backtrace.Tests/ClientTests/LogCreationBase.cs
+++ b/Backtrace.Tests/ClientTests/LogCreationBase.cs
@@ -15,7 +15,9 @@ namespace Backtrace.Tests.ClientTests
         public virtual void Setup()
         {
             var api = new Mock<IBacktraceApi>();
-            api.Setup(n => n.Send(It.IsAny<BacktraceData>())).Returns(new BacktraceResult());
+            api.Setup(n => n.Send(It.IsAny<BacktraceData>()))
+                .Returns(new BacktraceResult() { Status = Types.BacktraceResultStatus.Ok });
+
             var credentials = new BacktraceCredentials(@"https://validurl.com/", "validToken");
             _backtraceClient = new BacktraceClient(credentials)
             {

--- a/Backtrace.Tests/ClientTests/LogCreationBase.cs
+++ b/Backtrace.Tests/ClientTests/LogCreationBase.cs
@@ -2,11 +2,7 @@
 using Backtrace.Model;
 using Moq;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Backtrace.Tests.ClientTests
 {

--- a/Backtrace.Tests/DatabaseTests/DatabaseSetupTests.cs
+++ b/Backtrace.Tests/DatabaseTests/DatabaseSetupTests.cs
@@ -20,7 +20,7 @@ namespace Backtrace.Tests.DatabaseTests
         /// <summary>
         /// Current project directory
         /// </summary>
-        private readonly string _projectDirectory = Environment.CurrentDirectory;
+        private readonly string _projectDirectory = System.IO.Path.GetTempPath();
 
         [Test(Author = "Konrad Dysput", Description = "Test database initialization")]
         public void TestDatabaseInitalizationConditions()

--- a/Backtrace.Tests/DatabaseTests/Model/DatabaseTestBase.cs
+++ b/Backtrace.Tests/DatabaseTests/Model/DatabaseTestBase.cs
@@ -44,6 +44,7 @@ namespace Backtrace.Tests.DatabaseTests.Model
 
             var settings = new BacktraceDatabaseSettings(projectPath)
             {
+                RetryBehavior = RetryBehavior.NoRetry,
                 AutoSendMode = false, //we don't want to test timers
                 MaxRecordCount = 100,
                 RetryLimit = 3

--- a/Backtrace.Tests/DatabaseTests/Model/DatabaseTestBase.cs
+++ b/Backtrace.Tests/DatabaseTests/Model/DatabaseTestBase.cs
@@ -1,6 +1,4 @@
-﻿using Backtrace.Base;
-using Backtrace.Interfaces;
-using Backtrace.Interfaces.Database;
+﻿using Backtrace.Interfaces;
 using Backtrace.Model;
 using Backtrace.Model.Database;
 using Backtrace.Services;
@@ -10,9 +8,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Backtrace.Tests.DatabaseTests.Model
 {
@@ -30,7 +25,7 @@ namespace Backtrace.Tests.DatabaseTests.Model
         public virtual void Setup()
         {
             //get project path
-            string projectPath = Environment.CurrentDirectory;
+            string projectPath = Path.GetTempPath();
 
             //mock api
             var mockApi = new Mock<IBacktraceApi>();
@@ -51,7 +46,7 @@ namespace Backtrace.Tests.DatabaseTests.Model
             {
                 AutoSendMode = false, //we don't want to test timers
                 MaxRecordCount = 100,
-                RetryLimit = 3 
+                RetryLimit = 3
             };
             _database = new BacktraceDatabase(settings)
             {
@@ -85,6 +80,9 @@ namespace Backtrace.Tests.DatabaseTests.Model
             mockRecord.Setup(n => n.Delete());
             mockRecord.Setup(n => n.BacktraceData)
                 .Returns(new BacktraceData(It.IsAny<BacktraceReport>(), It.IsAny<Dictionary<string, object>>()));
+            mockRecord.Setup(n => n.Valid())
+                .Returns(true);
+
             var data = new BacktraceData(null, new Dictionary<string, object>());
             mockRecord.SetupProperty(n => n.Record, data);
 

--- a/Backtrace.Tests/EnvironmentTests/BacktraceAttributesTests.cs
+++ b/Backtrace.Tests/EnvironmentTests/BacktraceAttributesTests.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
-using Backtrace.Base;
-using Backtrace.Model;
+﻿using Backtrace.Model;
 using Backtrace.Model.JsonData;
 using NUnit.Framework;
+using System.Collections.Generic;
 namespace Backtrace.Tests.EnvironmentTests
 {
     /// <summary>
@@ -24,15 +20,47 @@ namespace Backtrace.Tests.EnvironmentTests
             //test empty exception
             Assert.DoesNotThrow(() =>
             {
-                var backtraceAttributes = new BacktraceAttributes(report,new Dictionary<string, object>());
+                var backtraceAttributes = new BacktraceAttributes(report, new Dictionary<string, object>());
                 backtraceAttributes.SetExceptionAttributes(new BacktraceReport("message"));
             });
             //test null
             Assert.DoesNotThrow(() =>
             {
-                var backtraceAttributes = new BacktraceAttributes(report,new Dictionary<string, object>());
+                var backtraceAttributes = new BacktraceAttributes(report, new Dictionary<string, object>());
                 backtraceAttributes.SetExceptionAttributes(null);
             });
+        }
+
+
+        [Test]
+        public void TestFingerprintAttribute()
+        {
+            string fingerprint = "fingerprint for testing purpose";
+            var report = new BacktraceReport("testMessage")
+            {
+                Fingerprint = fingerprint
+            };
+            var attributes = new BacktraceAttributes(report, null);
+            Assert.IsTrue(attributes.Attributes.ContainsKey("_mod_fingerprint"));
+            Assert.IsFalse(attributes.Attributes.ContainsKey("_mod_factor"));
+
+            Assert.AreEqual(attributes.Attributes["_mod_fingerprint"], fingerprint);
+        }
+
+        [Test]
+        public void TestFactorAttribute()
+        {
+            string factor = "factor attribute value";
+            var report = new BacktraceReport("testMessage")
+            {
+                Factor = factor
+            };
+
+            var attributes = new BacktraceAttributes(report, null);
+            Assert.IsTrue(attributes.Attributes.ContainsKey("_mod_factor"));
+
+            Assert.AreEqual(attributes.Attributes["_mod_factor"], factor);
+            Assert.IsFalse(attributes.Attributes.ContainsKey("_mod_fingerprint"));
         }
     }
 }

--- a/Backtrace.Tests/IntegrationTests/DatabaseEventBehaviourTests.cs
+++ b/Backtrace.Tests/IntegrationTests/DatabaseEventBehaviourTests.cs
@@ -56,7 +56,7 @@ namespace Backtrace.Tests.DatabaseTests
         {
             _lastEntry = GetEntry();
             //get project path
-            string projectPath = Environment.CurrentDirectory;
+            string projectPath = System.IO.Path.GetTempPath();
             //setup credentials
             var credentials = new BacktraceCredentials("https://validurl.com/", "validToken");
             //mock api

--- a/Backtrace.Tests/IntegrationTests/DatabaseIntegrationTests.cs
+++ b/Backtrace.Tests/IntegrationTests/DatabaseIntegrationTests.cs
@@ -1,5 +1,4 @@
-﻿using Backtrace.Base;
-using Backtrace.Extensions;
+﻿using Backtrace.Extensions;
 using Backtrace.Interfaces;
 using Backtrace.Model;
 using Backtrace.Model.Database;
@@ -12,8 +11,6 @@ using RichardSzalay.MockHttp;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Backtrace.Tests.IntegrationTests
@@ -24,19 +21,18 @@ namespace Backtrace.Tests.IntegrationTests
         /// <summary>
         /// Client
         /// </summary>
-        BacktraceClient _backtraceClient;
+        private BacktraceClient _backtraceClient;
 
         /// <summary>
         /// Last database record
         /// </summary>
-        BacktraceDatabaseRecord _lastRecord;
+        private BacktraceDatabaseRecord _lastRecord;
 
         /// <summary>
         /// Enable hard drive write errors
         /// </summary>
-        bool _enableWriteErrors = false;
-
-        bool _writeFail = false;
+        private bool _enableWriteErrors = false;
+        private bool _writeFail = false;
 
         /// <summary>
         /// Get new database record 
@@ -64,7 +60,7 @@ namespace Backtrace.Tests.IntegrationTests
         {
             _lastRecord = GetRecord();
             //get project path
-            string projectPath = Environment.CurrentDirectory;
+            string projectPath = Path.GetTempPath();
             //setup credentials
             var credentials = new BacktraceCredentials("https://validurl.com/", "validToken");
             //mock api

--- a/Backtrace/Backtrace.csproj
+++ b/Backtrace/Backtrace.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net45;net35</TargetFrameworks>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</PackageTags>
-    <PackageVersion>2.0.2</PackageVersion>
+    <PackageVersion>2.0.3</PackageVersion>
     <Product>Backtrace</Product>
     <PackageLicenseUrl>https://github.com/backtrace-labs/backtrace-csharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/backtrace-labs/backtrace-csharp</PackageProjectUrl>
@@ -12,12 +12,12 @@
     <Description>Backtrace's integration with C# applications allows customers to capture and report handled and unhandled C# exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.</Description>
     <RepositoryUrl>https://github.com/backtrace-labs/backtrace-csharp</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <Copyright>Backtrace I/O</Copyright>
     <Authors>Backtrace I/O</Authors>
     <Company>Backtrace I/O</Company>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
+    <AssemblyVersion>2.0.3.0</AssemblyVersion>
+    <FileVersion>2.0.3.0</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Backtrace/Backtrace.csproj
+++ b/Backtrace/Backtrace.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net45;net35</TargetFrameworks>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</PackageTags>
-    <PackageVersion>2.0.3</PackageVersion>
+    <PackageVersion>2.0.4</PackageVersion>
     <Product>Backtrace</Product>
     <PackageLicenseUrl>https://github.com/backtrace-labs/backtrace-csharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/backtrace-labs/backtrace-csharp</PackageProjectUrl>
@@ -12,12 +12,12 @@
     <Description>Backtrace's integration with C# applications allows customers to capture and report handled and unhandled C# exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.</Description>
     <RepositoryUrl>https://github.com/backtrace-labs/backtrace-csharp</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <Copyright>Backtrace I/O</Copyright>
     <Authors>Backtrace I/O</Authors>
     <Company>Backtrace I/O</Company>
-    <AssemblyVersion>2.0.3.0</AssemblyVersion>
-    <FileVersion>2.0.3.0</FileVersion>
+    <AssemblyVersion>2.0.4.0</AssemblyVersion>
+    <FileVersion>2.0.4.0</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Backtrace/BacktraceClient.cs
+++ b/Backtrace/BacktraceClient.cs
@@ -16,6 +16,11 @@ namespace Backtrace
     public class BacktraceClient : BacktraceBase, IBacktraceClient
     {
         /// <summary>
+        /// Ignore AggregateException and only prepare report for inner exceptions
+        /// </summary>
+        public bool IgnoreAggregateException { get; set; } = false;
+
+        /// <summary>
         /// Set an event executed before sending data to Backtrace API
         /// </summary>
         public Action<BacktraceReport> OnReportStart;

--- a/Backtrace/BacktraceClient.cs
+++ b/Backtrace/BacktraceClient.cs
@@ -164,7 +164,8 @@ namespace Backtrace
             Dictionary<string, object> attributes = null,
             List<string> attachmentPaths = null)
         {
-            return Send(new BacktraceReport(exception, attributes, attachmentPaths));
+            var report = new BacktraceReport(exception, attributes, attachmentPaths);
+            return Send(report);
         }
 
         /// <summary>
@@ -178,7 +179,8 @@ namespace Backtrace
             Dictionary<string, object> attributes = null,
             List<string> attachmentPaths = null)
         {
-            return Send(new BacktraceReport(message, attributes, attachmentPaths));
+            var report = new BacktraceReport(message, attributes, attachmentPaths);
+            return Send(report);
         }
 
         /// <summary>

--- a/Backtrace/BacktraceClient.cs
+++ b/Backtrace/BacktraceClient.cs
@@ -16,11 +16,6 @@ namespace Backtrace
     public class BacktraceClient : BacktraceBase, IBacktraceClient
     {
         /// <summary>
-        /// Ignore AggregateException and only prepare report for inner exceptions
-        /// </summary>
-        public bool IgnoreAggregateException { get; set; } = false;
-
-        /// <summary>
         /// Set an event executed before sending data to Backtrace API
         /// </summary>
         public Action<BacktraceReport> OnReportStart;
@@ -164,7 +159,6 @@ namespace Backtrace
         /// <param name="exception">Current exception</param>
         /// <param name="attributes">Additional information about application state</param>
         /// <param name="attachmentPaths">Path to all report attachments</param>
-        [Obsolete("Send is obsolete, please use SendAsync instead if possible.")]
         public virtual BacktraceResult Send(
             Exception exception,
             Dictionary<string, object> attributes = null,
@@ -179,7 +173,6 @@ namespace Backtrace
         /// <param name="message">Custom client message</param>
         /// <param name="attributes">Additional information about application state</param>
         /// <param name="attachmentPaths">Path to all report attachments</param>
-        [Obsolete("Send is obsolete, please use SendAsync instead if possible.")]
         public virtual BacktraceResult Send(
             string message,
             Dictionary<string, object> attributes = null,
@@ -192,7 +185,6 @@ namespace Backtrace
         /// Sending a backtrace report to Backtrace API
         /// </summary>
         /// <param name="backtraceReport">Current report</param>
-        [Obsolete("Send is obsolete, please use SendAsync instead if possible.")]
         public override BacktraceResult Send(BacktraceReport backtraceReport)
         {
             OnReportStart?.Invoke(backtraceReport);

--- a/Backtrace/BacktraceDatabase.cs
+++ b/Backtrace/BacktraceDatabase.cs
@@ -164,7 +164,7 @@ namespace Backtrace
         /// </summary>
         public BacktraceDatabaseRecord Add(BacktraceReport backtraceReport, Dictionary<string, object> attributes, MiniDumpType miniDumpType = MiniDumpType.Normal)
         {
-            if (!_enable)
+            if (!_enable || backtraceReport == null)
             {
                 return null;
             }

--- a/Backtrace/BacktraceDatabase.cs
+++ b/Backtrace/BacktraceDatabase.cs
@@ -1,5 +1,4 @@
-﻿using Backtrace.Base;
-using Backtrace.Common;
+﻿using Backtrace.Common;
 using Backtrace.Interfaces;
 using Backtrace.Model;
 using Backtrace.Model.Database;
@@ -9,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Timers;
-using System.Diagnostics;
 #if !NET35
 using System.Threading.Tasks;
 #endif
@@ -170,14 +168,7 @@ namespace Backtrace
             {
                 return null;
             }
-            if (BacktraceDatabaseContext.Count() + 1 > DatabaseSettings.MaxRecordCount && DatabaseSettings.MaxRecordCount != 0)
-            {
-                throw new ArgumentException("Maximum number of records available in BacktraceDatabase");
-            }
-            if (BacktraceDatabaseContext.GetSize() > DatabaseSettings.MaxDatabaseSize && DatabaseSettings.MaxDatabaseSize != 0)
-            {
-                throw new ArgumentException("You don't have enought space in database for more records");
-            }
+            ValidateDatabaseSize();
             if (miniDumpType != MiniDumpType.None)
             {
                 string minidumpPath = GenerateMiniDump(backtraceReport, miniDumpType);
@@ -196,13 +187,19 @@ namespace Backtrace
         /// Get all stored records in BacktraceDatabase
         /// </summary>
         /// <returns>All stored records in BacktraceDatabase</returns>
-        public IEnumerable<BacktraceDatabaseRecord> Get() => BacktraceDatabaseContext?.Get() ?? new List<BacktraceDatabaseRecord>();
+        public IEnumerable<BacktraceDatabaseRecord> Get()
+        {
+            return BacktraceDatabaseContext?.Get() ?? new List<BacktraceDatabaseRecord>();
+        }
 
         /// <summary>
         /// Delete single record from database
         /// </summary>
         /// <param name="record">Record to delete</param>
-        public void Delete(BacktraceDatabaseRecord record) => BacktraceDatabaseContext?.Delete(record);
+        public void Delete(BacktraceDatabaseRecord record)
+        {
+            BacktraceDatabaseContext?.Delete(record);
+        }
 
         /// <summary>
         /// Send and delete all records from database
@@ -250,7 +247,11 @@ namespace Backtrace
 
         private async void OnTimedEventAsync(object source, ElapsedEventArgs e)
         {
-            if (!BacktraceDatabaseContext.Any() || _timerBackgroundWork) return;
+            if (!BacktraceDatabaseContext.Any() || _timerBackgroundWork)
+            {
+                return;
+            }
+
             _timerBackgroundWork = true;
             _timer.Stop();
             //read first record (keep in mind LIFO and FIFO settings) from memory database
@@ -287,7 +288,11 @@ namespace Backtrace
 #endif
         private void OnTimedEvent(object source, ElapsedEventArgs e)
         {
-            if (!BacktraceDatabaseContext.Any() || _timerBackgroundWork) return;
+            if (!BacktraceDatabaseContext.Any() || _timerBackgroundWork)
+            {
+                return;
+            }
+
             _timerBackgroundWork = true;
             _timer.Stop();
             //read first record (keep in mind LIFO and FIFO settings) from memory database
@@ -352,7 +357,10 @@ namespace Backtrace
         /// Get total number of records in database
         /// </summary>
         /// <returns>Total number of records</returns>
-        internal int Count() => BacktraceDatabaseContext.Count();
+        internal int Count()
+        {
+            return BacktraceDatabaseContext.Count();
+        }
 
         /// <summary>
         /// Detect all orphaned minidump and files
@@ -378,21 +386,35 @@ namespace Backtrace
                     continue;
                 }
                 BacktraceDatabaseContext.Add(record);
-                if (!ValidDatabaseSize())
-                {
-                    throw new ArgumentException("Database directory has too many records or database size is bigger than in option declaration.");
-                }
+                ValidateDatabaseSize();
                 record.Dispose();
             }
         }
         /// <summary>
-        /// Check current size of database
+        /// Validate database size - check how many records are stored 
+        /// in database and how much records need space.
+        /// If space or number of records are invalid
+        /// database will remove old reports
         /// </summary>
-        /// <returns>False if BacktraceDatabase doesn't have more free space</returns>
-        private bool ValidDatabaseSize()
+        private void ValidateDatabaseSize()
         {
-            return ((BacktraceDatabaseContext.GetSize() < DatabaseSettings.MaxDatabaseSize || DatabaseSettings.MaxDatabaseSize == 0)
-                || (BacktraceDatabaseContext.GetTotalNumberOfRecords() < DatabaseSettings.MaxRecordCount || DatabaseSettings.MaxDatabaseSize == 0));
+            //check how many records are stored in database
+            //remove in case when we want to store one more than expected number
+            //If record count == 0 then we ignore this condition
+            if (BacktraceDatabaseContext.Count() + 1 > DatabaseSettings.MaxRecordCount && DatabaseSettings.MaxRecordCount != 0)
+            {
+                BacktraceDatabaseContext.RemoveLastRecord();
+            }
+
+            //check database size. If database size == 0 then we ignore this condition
+            //remove all records till database use enough space
+            if (DatabaseSettings.MaxDatabaseSize != 0)
+            {
+                while (BacktraceDatabaseContext.GetSize() > DatabaseSettings.MaxDatabaseSize)
+                {
+                    BacktraceDatabaseContext.RemoveLastRecord();
+                }
+            }
         }
 
         /// <summary>

--- a/Backtrace/Base/BacktraceBase.cs
+++ b/Backtrace/Base/BacktraceBase.cs
@@ -21,7 +21,7 @@ namespace Backtrace.Base
         /// <summary>
         /// Ignore AggregateException and only prepare report for inner exceptions
         /// </summary>
-        public bool IgnoreAggregateException { get; set; } = false;
+        public bool UnpackAggregateExcetpion { get; set; } = false;
 #endif
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Backtrace.Base
         public virtual BacktraceResult Send(BacktraceReport report)
         {
 #if !NET35
-            if (IgnoreAggregateException && report.Exception is AggregateException)
+            if (UnpackAggregateExcetpion && report.Exception is AggregateException)
             {
                 return HandleAggregateException(report).Result;
             }
@@ -195,7 +195,7 @@ namespace Backtrace.Base
         /// <param name="report">Report to send</param>
         public virtual async Task<BacktraceResult> SendAsync(BacktraceReport report)
         {
-            if (IgnoreAggregateException && report.Exception is AggregateException)
+            if (UnpackAggregateExcetpion && report.Exception is AggregateException)
             {
                 return await HandleAggregateException(report);
             }

--- a/Backtrace/Base/BacktraceBase.cs
+++ b/Backtrace/Base/BacktraceBase.cs
@@ -18,6 +18,11 @@ namespace Backtrace.Base
     public class BacktraceBase
     {
         /// <summary>
+        /// Ignore AggregateException and only prepare report for inner exceptions
+        /// </summary>
+        public bool IgnoreAggregateException { get; set; } = false;
+
+        /// <summary>
         /// Custom request handler for HTTP call to server
         /// </summary>
         public Func<string, string, BacktraceData, BacktraceResult> RequestHandler
@@ -139,9 +144,12 @@ namespace Backtrace.Base
         /// Send a report to Backtrace API
         /// </summary>
         /// <param name="report">Report to send</param>
+#if !NET35
         [Obsolete("Send is obsolete, please use SendAsync instead if possible.")]
+#endif
         public virtual BacktraceResult Send(BacktraceReport report)
         {
+            System.Diagnostics.Debug.WriteLine("Missing aggreaget exception implementation");
             var record = Database.Add(report, Attributes, MiniDumpType);
             //create a JSON payload instance
             var data = record?.BacktraceData ?? report.ToBacktraceData(Attributes);
@@ -183,6 +191,19 @@ namespace Backtrace.Base
         /// <param name="report">Report to send</param>
         public virtual async Task<BacktraceResult> SendAsync(BacktraceReport report)
         {
+            System.Diagnostics.Debug.WriteLine("Missing aggreaget exception implementation");
+            //if (IgnoreAggregateException && report.Exception is AggregateException)
+            //{
+            //    var aggregateException = report.Exception as AggregateException;
+            //    aggregateException.Handle(e =>
+            //    {
+
+            //        return true;
+            //    });
+            //    //unpack report to check inner exception
+            //    throw new NotImplementedException(nameof(IgnoreAggregateException));
+
+            //}
             var record = Database.Add(report, Attributes, MiniDumpType);
             //create a JSON payload instance
             var data = record?.BacktraceData ?? report.ToBacktraceData(Attributes);

--- a/Backtrace/Base/BacktraceBase.cs
+++ b/Backtrace/Base/BacktraceBase.cs
@@ -22,28 +22,16 @@ namespace Backtrace.Base
         /// </summary>
         public Func<string, string, BacktraceData, BacktraceResult> RequestHandler
         {
-            get
-            {
-                return BacktraceApi.RequestHandler;
-            }
-            set
-            {
-                BacktraceApi.RequestHandler = value;
-            }
+            get => BacktraceApi.RequestHandler;
+            set => BacktraceApi.RequestHandler = value;
         }
         /// <summary>
         /// Set an event executed when received bad request, unauthorize request or other information from server
         /// </summary>
         public Action<Exception> OnServerError
         {
-            get
-            {
-                return BacktraceApi.OnServerError;
-            }
-            set
-            {
-                BacktraceApi.OnServerError = value;
-            }
+            get => BacktraceApi.OnServerError;
+            set => BacktraceApi.OnServerError = value;
         }
 
         /// <summary>
@@ -51,14 +39,8 @@ namespace Backtrace.Base
         /// </summary>
         public Action<BacktraceResult> OnServerResponse
         {
-            get
-            {
-                return BacktraceApi.OnServerResponse;
-            }
-            set
-            {
-                BacktraceApi.OnServerResponse = value;
-            }
+            get => BacktraceApi.OnServerResponse;
+            set => BacktraceApi.OnServerResponse = value;
         }
 
         /// <summary>
@@ -71,10 +53,7 @@ namespace Backtrace.Base
         /// </summary>
         public Action<BacktraceReport> OnClientReportLimitReached
         {
-            set
-            {
-                BacktraceApi.SetClientRateLimitEvent(value);
-            }
+            set => BacktraceApi.SetClientRateLimitEvent(value);
         }
 
         /// <summary>
@@ -103,10 +82,7 @@ namespace Backtrace.Base
         /// </summary>
         internal IBacktraceApi BacktraceApi
         {
-            get
-            {
-                return _backtraceApi;
-            }
+            get => _backtraceApi;
             set
             {
                 _backtraceApi = value;

--- a/Backtrace/Extensions/DictionaryExtensions.cs
+++ b/Backtrace/Extensions/DictionaryExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Backtrace.Extensions
 {
@@ -20,11 +18,11 @@ namespace Backtrace.Extensions
         internal static Dictionary<string, object> Merge(
             this Dictionary<string, object> source, Dictionary<string, object> toMerge)
         {
-            if(source == null)
+            if (source == null)
             {
                 throw new ArgumentException(nameof(source));
             }
-            if(toMerge == null)
+            if (toMerge == null)
             {
                 throw new ArgumentException(nameof(toMerge));
             }

--- a/Backtrace/Interfaces/IBacktraceDatabaseContext.cs
+++ b/Backtrace/Interfaces/IBacktraceDatabaseContext.cs
@@ -85,9 +85,8 @@ namespace Backtrace.Interfaces
         int GetTotalNumberOfRecords();
 
         /// <summary>
-        /// Get all repots stored in Database
+        /// Remove the oldest record in database
         /// </summary>
-        //IEnumerable<BacktraceReportBase> Get(Func<BacktraceReportBase,IEnumerable<BacktraceReportBase) filter);
-
+        void RemoveLastRecord();
     }
 }

--- a/Backtrace/Interfaces/IBacktraceDatabaseContext.cs
+++ b/Backtrace/Interfaces/IBacktraceDatabaseContext.cs
@@ -85,8 +85,9 @@ namespace Backtrace.Interfaces
         int GetTotalNumberOfRecords();
 
         /// <summary>
-        /// Remove the oldest record in database
+        /// Remove last record in database. 
         /// </summary>
-        void RemoveLastRecord();
+        /// <returns>If algorithm can remove last record, method return true. Otherwise false</returns>
+        bool RemoveLastRecord();
     }
 }

--- a/Backtrace/Model/BacktraceReport.cs
+++ b/Backtrace/Model/BacktraceReport.cs
@@ -1,12 +1,7 @@
-﻿using Backtrace.Common;
-using Backtrace.Extensions;
-using Backtrace.Model;
-using Backtrace.Model.JsonData;
+﻿using Backtrace.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 #if !NET35
 using System.Runtime.ExceptionServices;
@@ -21,6 +16,16 @@ namespace Backtrace.Model
     public class BacktraceReport
     {
         /// <summary>
+        /// Fingerprint
+        /// </summary>
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Factor
+        /// </summary>
+        public string Factor { get; set; }
+
+        /// <summary>
         /// 16 bytes of randomness in human readable UUID format
         /// server will reject request if uuid is already found
         /// </summary>s
@@ -31,7 +36,7 @@ namespace Backtrace.Model
         /// UTC timestamp in seconds
         /// </summary>
         [JsonProperty(PropertyName = "timestamp")]
-        public long Timestamp { get; private set; } = (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+        public long Timestamp { get; private set; } = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
         /// <summary>
         /// Get information aboout report type. If value is true the BacktraceReport has an error information
@@ -181,8 +186,8 @@ namespace Backtrace.Model
             {
                 return null;
             }
-            var copy = (BacktraceReport)this.MemberwiseClone();
-            copy.Exception = this.Exception.InnerException;
+            var copy = (BacktraceReport)MemberwiseClone();
+            copy.Exception = Exception.InnerException;
             copy.SetCallingAssemblyInformation();
             copy.Classifier = copy.Exception.GetType().Name;
             return copy;

--- a/Backtrace/Model/BacktraceResult.cs
+++ b/Backtrace/Model/BacktraceResult.cs
@@ -106,5 +106,15 @@ namespace Backtrace.Model
                 Status = BacktraceResultStatus.ServerError
             };
         }
+
+        internal void AddInnerResult(BacktraceResult innerResult)
+        {
+            if(InnerExceptionResult == null)
+            {
+                InnerExceptionResult = innerResult;
+                return;
+            }
+            InnerExceptionResult.AddInnerResult(innerResult);
+        }
     }
 }

--- a/Backtrace/Model/Database/BacktraceDatabaseRecord.cs
+++ b/Backtrace/Model/Database/BacktraceDatabaseRecord.cs
@@ -169,14 +169,16 @@ namespace Backtrace.Model.Database
                 RecordWriter.Write(this, $"{Id}-record");
                 return true;
             }
-            catch (IOException)
+            catch (IOException io)
             {
-                Trace.WriteLine($"Received {nameof(IOException)} while saving data to database");
+                Trace.WriteLine($"Received {nameof(IOException)} while saving data to database.");
+                Debug.WriteLine($"Message {io.Message}");
                 return false;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Trace.WriteLine($"Received {nameof(Exception)} while saving data to database");
+                Trace.WriteLine($"Received {nameof(Exception)} while saving data to database.");
+                Debug.WriteLine($"Message {ex.Message}");
                 return false;
             }
         }

--- a/Backtrace/Model/Database/BacktraceDatabaseRecord.cs
+++ b/Backtrace/Model/Database/BacktraceDatabaseRecord.cs
@@ -205,7 +205,7 @@ namespace Backtrace.Model.Database
         /// Check if all necessary files declared on record exists
         /// </summary>
         /// <returns>True if record is valid</returns>
-        public bool Valid()
+        internal virtual bool Valid()
         {
             return File.Exists(DiagnosticDataPath) && File.Exists(ReportPath);
         }

--- a/Backtrace/Model/Database/BacktraceDatabaseSettings.cs
+++ b/Backtrace/Model/Database/BacktraceDatabaseSettings.cs
@@ -65,6 +65,6 @@ namespace Backtrace.Model.Database
         /// </summary>
         public uint RetryLimit { get; set; } = 3;
 
-        public RetryOrder RetryOrder { get; set; } = RetryOrder.Stack;
+        public RetryOrder RetryOrder { get; set; } = RetryOrder.Queue;
     }
 }

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -39,7 +39,7 @@ namespace Backtrace.Model.JsonData
             if (report != null)
             {
                 ConvertAttributes(report, clientAttributes);
-                SetLibraryAttributes(report.CallingAssembly);
+                SetLibraryAttributes(report);
                 SetDebuggerAttributes(report.CallingAssembly);
                 SetExceptionAttributes(report);
             }
@@ -52,8 +52,18 @@ namespace Backtrace.Model.JsonData
         /// Set library attributes
         /// </summary>
         /// <param name="callingAssembly">Calling assembly</param>
-        private void SetLibraryAttributes(Assembly callingAssembly)
+        private void SetLibraryAttributes(BacktraceReport report)
         {
+            var callingAssembly = report.CallingAssembly;
+            if (!string.IsNullOrEmpty(report.Fingerprint))
+            {
+                Attributes["_mod_fingerprint"] = report.Fingerprint;
+            }
+
+            if (!string.IsNullOrEmpty(report.Factor))
+            {
+                Attributes["_mod_factor"] = report.Factor;
+            }
             //A unique identifier of a machine
             Attributes["guid"] = GenerateMachineId().ToString();
             //Base name of application generating the report

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -139,6 +139,11 @@ namespace Backtrace.Model.JsonData
                     ComplexAttributes.Add(attribute.Key, attribute.Value);
                 }
             }
+            //add exception information to Complex attributes.
+            if (report.ExceptionTypeReport)
+            {
+                ComplexAttributes.Add("Exception Properties", report.Exception);
+            }
         }
 
         /// <summary>
@@ -148,7 +153,9 @@ namespace Backtrace.Model.JsonData
         /// <returns>Machine uuid</returns>
         private Guid GenerateMachineId()
         {
-            var networkInterface = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(n => n.OperationalStatus == OperationalStatus.Up);
+            var networkInterface =
+                 NetworkInterface.GetAllNetworkInterfaces()
+                    .FirstOrDefault(n => n.OperationalStatus == OperationalStatus.Up);
 
             PhysicalAddress physicalAddr = null;
             string macAddress = null;

--- a/Backtrace/Model/JsonData/ThreadData.cs
+++ b/Backtrace/Model/JsonData/ThreadData.cs
@@ -1,13 +1,13 @@
 ﻿#if NET45
 using Microsoft.Diagnostics.Runtime;
 #endif
+using Backtrace.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Linq;
 using System.Reflection;
-using Backtrace.Extensions;
+using System.Threading;
 
 namespace Backtrace.Model.JsonData
 {
@@ -32,8 +32,16 @@ namespace Backtrace.Model.JsonData
         internal ThreadData(Assembly callingAssembly, IEnumerable<BacktraceStackFrame> exceptionStack)
         {
 #if NET45
-            //use available in .NET 4.5 api to find stack trace of all available managed threads
-            GetUsedThreads(callingAssembly);
+            try
+            {
+                //use available in .NET 4.5 api to find stack trace of all available managed threads
+                GetUsedThreads(callingAssembly);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine($"[ThreadData] Received exception: {e.Message}");
+                Trace.WriteLine("Cannot retrieve information about threads.");
+            }
 #else
             //get all available process threads
             ProcessThreads();
@@ -135,7 +143,7 @@ namespace Backtrace.Model.JsonData
                     var frames = new List<BacktraceStackFrame>();
                     foreach (var frame in thread.StackTrace)
                     {
-                        if(frame.Method == null)
+                        if (frame.Method == null)
                         {
                             continue;
                         }

--- a/Backtrace/Services/BacktraceDatabaseContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseContext.cs
@@ -174,9 +174,10 @@ namespace Backtrace.Services
         }
 
         /// <summary>
-        /// Remove last record in database
+        /// Remove last record in database. 
         /// </summary>
-        public void RemoveLastRecord()
+        /// <returns>If algorithm can remove last record, method return true. Otherwise false</returns>
+        public bool RemoveLastRecord()
         {
             var record = LastOrDefault();
             if (record != null)
@@ -185,7 +186,9 @@ namespace Backtrace.Services
                 TotalRecords--;
                 TotalSize -= record.Size;
                 System.Diagnostics.Debug.WriteLine($"[RemoveLastRecord] :: Total Size = {TotalSize}");
+                return true;
             }
+            return false;
         }
 
         /// <summary>

--- a/Backtrace/Services/BacktraceDatabaseContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseContext.cs
@@ -4,7 +4,6 @@ using Backtrace.Model.Database;
 using Backtrace.Types;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]
@@ -81,7 +80,10 @@ namespace Backtrace.Services
         /// <returns>New instance of DatabaseRecordy</returns>
         public virtual BacktraceDatabaseRecord Add(BacktraceData backtraceData)
         {
-            if (backtraceData == null) throw new NullReferenceException(nameof(backtraceData));
+            if (backtraceData == null)
+            {
+                throw new NullReferenceException(nameof(backtraceData));
+            }
             //create new record and save it on hard drive
             var record = new BacktraceDatabaseRecord(backtraceData, _path);
             record.Save();
@@ -95,7 +97,10 @@ namespace Backtrace.Services
         /// <param name="backtraceRecord">Database record</param>
         public BacktraceDatabaseRecord Add(BacktraceDatabaseRecord backtraceRecord)
         {
-            if (backtraceRecord == null) throw new NullReferenceException(nameof(BacktraceDatabaseRecord));
+            if (backtraceRecord == null)
+            {
+                throw new NullReferenceException(nameof(BacktraceDatabaseRecord));
+            }
             //lock record, because Add method returns record
             backtraceRecord.Locked = true;
             //increment total size of database
@@ -151,6 +156,7 @@ namespace Backtrace.Services
                         TotalRecords--;
                         //decrement total size of database
                         TotalSize -= value.Size;
+                        System.Diagnostics.Debug.WriteLine($"[Delete] :: Total Size = {TotalSize}");
                         return;
                     }
                 }
@@ -165,6 +171,21 @@ namespace Backtrace.Services
         {
             RemoveMaxRetries();
             IncrementBatches();
+        }
+
+        /// <summary>
+        /// Remove last record in database
+        /// </summary>
+        public void RemoveLastRecord()
+        {
+            var record = LastOrDefault();
+            if (record != null)
+            {
+                record.Delete();
+                TotalRecords--;
+                TotalSize -= record.Size;
+                System.Diagnostics.Debug.WriteLine($"[RemoveLastRecord] :: Total Size = {TotalSize}");
+            }
         }
 
         /// <summary>
@@ -190,10 +211,15 @@ namespace Backtrace.Services
             for (int i = 0; i < total; i++)
             {
                 var value = currentBatch[i];
-                value.Delete();
-                TotalRecords--;
-                //decrement total size of database
-                TotalSize -= value.Size;
+                if (value.Valid())
+                {
+                    value.Delete();
+                    TotalRecords--;
+                    //decrement total size of database
+                    System.Diagnostics.Debug.WriteLine($"[RemoveMaxRetries]::BeforeDelete Total size: {TotalSize}. Record Size: {value.Size} ");
+                    TotalSize -= value.Size;
+                    System.Diagnostics.Debug.WriteLine($"[RemoveMaxRetries]::AfterDelete Total size: {TotalSize} ");
+                }
             }
         }
 
@@ -210,7 +236,10 @@ namespace Backtrace.Services
         /// Get total number of records in database
         /// </summary>
         /// <returns></returns>
-        public int Count() => TotalRecords;
+        public int Count()
+        {
+            return TotalRecords;
+        }
 
         /// <summary>
         /// Dispose

--- a/Backtrace/Services/BacktraceDatabaseContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseContext.cs
@@ -303,7 +303,6 @@ namespace Backtrace.Services
             //get all batches (from the beginning)
             for (int i = 0; i < _retryNumber; i++)
             {
-                System.Diagnostics.Debug.WriteLine("Current iteration: " + i);
                 //if batch has any record that is not used
                 //set lock to true 
                 //and return file

--- a/Backtrace/Services/BacktraceDatabaseContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseContext.cs
@@ -298,8 +298,9 @@ namespace Backtrace.Services
         private BacktraceDatabaseRecord GetFirstRecord()
         {
             //get all batches (from the beginning)
-            for (int i = 0; i < _retryNumber - 1; i++)
+            for (int i = 0; i < _retryNumber; i++)
             {
+                System.Diagnostics.Debug.WriteLine("Current iteration: " + i);
                 //if batch has any record that is not used
                 //set lock to true 
                 //and return file

--- a/Backtrace/Services/BacktraceDatabaseFileContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseFileContext.cs
@@ -141,7 +141,6 @@ namespace Backtrace.Services
                 var file = files[i];
                 file.Delete();
             }
-
         }
     }
 }

--- a/Backtrace/Types/BacktraceResultStatus.cs
+++ b/Backtrace/Types/BacktraceResultStatus.cs
@@ -20,6 +20,10 @@ namespace Backtrace.Types
         /// <summary>
         /// Set when data were send to API
         /// </summary>
-        Ok
+        Ok,
+        /// <summary>
+        /// Status generated Backtrace client receive empty report (Aggregate Exception purpose)
+        /// </summary>
+        Empty
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ﻿# Backtrace C# Release Notes
 
+## Version 2.0.4 - 23.09.2018
+- `BacktraceClient` allows developer to unpack `AggregateException` and send only exceptions available in `InnerExceptions` property.
+- `BacktraceReport` accepts two new properties: `Factory` and `Fingerprint`. These properties allows you to change server side algorithms. 
+- `BacktraceData` now include informations about `Exception` properties. You can check detailed `Exception` properties in Annotations.
+- `BacktraceDatabase` doesn't throw exception when developer can't add new record. This situation exists when database was full or database hasn't enough disk space for exceptions.
+- `BacktraceResult` can use new `Status`. In case when developer want to unpack `AggregateException` and `InnerExceptions` property is empty, `BacktraceClient` return `BacktraceResult` with status `Empty`,
+
 ## Version 2.0.3 - 04.09.2018
 - Thread data condition for Unity on .NET Framework 4.5+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0.4 - 23.09.2018
 - `BacktraceClient` allows developer to unpack `AggregateException` and send only exceptions available in `InnerExceptions` property.
-- `BacktraceReport` accepts two new properties: `Factory` and `Fingerprint`. These properties allows you to change server side algorithms. 
+- `BacktraceReport` accepts two new properties: `Factor` and `Fingerprint`. These properties allows you to change server side algorithms. 
 - `BacktraceData` now include informations about `Exception` properties. You can check detailed `Exception` properties in Annotations.
 - `BacktraceDatabase` doesn't throw exception when developer can't add new record. This situation exists when database was full or database hasn't enough disk space for exceptions.
 - `BacktraceResult` can use new `Status`. In case when developer want to unpack `AggregateException` and `InnerExceptions` property is empty, `BacktraceClient` return `BacktraceResult` with status `Empty`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# Backtrace C# Release Notes
 
+## Version 2.0.3 - 04.09.2018
+- Thread data condition for Unity on .NET Framework 4.5+
+
 ## Version 2.0.2 - 28.08.2018
 - Nullable environment variables fix,
 - Fix for invalid database tests that use real minidump files,

--- a/Examples/Backtrace.Core/Program.cs
+++ b/Examples/Backtrace.Core/Program.cs
@@ -37,7 +37,6 @@ namespace Backtrace.Core
 
         public async Task Start()
         {
-            await Task.Delay(int.MaxValue);
             await GenerateRandomStrings();
             await TryClean();
             //handle uncaught exception from unsafe code

--- a/Examples/Backtrace.Framework45Example/ApplicationSettings.cs
+++ b/Examples/Backtrace.Framework45Example/ApplicationSettings.cs
@@ -8,8 +8,8 @@ namespace Backtrace.Framework45Example
 {
     public static class ApplicationSettings
     {
-        public const string Host = @"https://myserver.sp.backtrace.io:6097";
-        public const string Token = "4dca18e8769d0f5d10db0d1b665e64b3d716f76bf182fbcdad5d1d8070c12db0";
+        public const string Host = @"http://yolo.sp.backtrace.io:6097/";
+        public const string Token = "328174ab5c377e2cdcb6c763ec2bbdf1f9aa5282c1f6bede693efe06a479db54";
         public const string DatabasePath = "";
     }
 }

--- a/Examples/Backtrace.Framework45Example/ApplicationSettings.cs
+++ b/Examples/Backtrace.Framework45Example/ApplicationSettings.cs
@@ -8,8 +8,8 @@ namespace Backtrace.Framework45Example
 {
     public static class ApplicationSettings
     {
-        public const string Host = @"http://yolo.sp.backtrace.io:6097/";
-        public const string Token = "328174ab5c377e2cdcb6c763ec2bbdf1f9aa5282c1f6bede693efe06a479db54";
+        public const string Host = @"https://myserver.sp.backtrace.io:6097";
+        public const string Token = "4dca18e8769d0f5d10db0d1b665e64b3d716f76bf182fbcdad5d1d8070c12db0";
         public const string DatabasePath = "";
     }
 }

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -31,19 +31,6 @@ namespace Backtrace.Framework45Example
         public Program()
         {
             SetupBacktraceLibrary();
-            var exception = new AggregateException("something really bad happend", new List<Exception>()
-            {
-                new InvalidOperationException("You won't execute this line of code for sure"),
-                new ArgumentException("Really bad argument"),
-                new FormatException("I don't have more funny exception descriptions lol"),
-                new AggregateException("Another aggregateException", new List<Exception> ()
-                {
-                    new DivideByZeroException("meh")
-                })
-            });
-
-            backtraceClient.IgnoreAggregateException = true;
-            var result = backtraceClient.Send(exception);
         }
 
         public async Task Start()
@@ -173,7 +160,10 @@ namespace Backtrace.Framework45Example
             //create Backtrace database
             var database = new BacktraceDatabase(databaseSettings);
             //setup new client
-            backtraceClient = new BacktraceClient(configuartion, database);
+            backtraceClient = new BacktraceClient(configuartion, database)
+            {
+                IgnoreAggregateException = true
+            };
 
             //handle all unhandled application exceptions
             backtraceClient.HandleApplicationException();

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -9,19 +9,19 @@ using System.Threading.Tasks;
 
 namespace Backtrace.Framework45Example
 {
-    class Program
+    internal class Program
     {
         private Tree tree;
 
         /// <summary>
         /// Credentials
         /// </summary>
-        private BacktraceCredentials credentials = new BacktraceCredentials(ApplicationSettings.Host, ApplicationSettings.Token);
+        private readonly BacktraceCredentials credentials = new BacktraceCredentials(ApplicationSettings.Host, ApplicationSettings.Token);
 
         /// <summary>
         /// Database settings
         /// </summary>
-        private BacktraceDatabaseSettings databaseSettings = new BacktraceDatabaseSettings(ApplicationSettings.DatabasePath);
+        private readonly BacktraceDatabaseSettings databaseSettings = new BacktraceDatabaseSettings(ApplicationSettings.DatabasePath);
 
         /// <summary>
         /// New instance of BacktraceClient. Check SetupBacktraceLibrary method for intiailization example
@@ -31,6 +31,14 @@ namespace Backtrace.Framework45Example
         public Program()
         {
             SetupBacktraceLibrary();
+            var exception = new AggregateException("something really bad happend", new List<Exception>()
+            {
+                new ArgumentException("Really bad argument"),
+                new InvalidOperationException("You won't execute this line of code for sure"),
+                new FormatException("I don't have more funny exception descriptions lol")
+            });
+            backtraceClient.IgnoreAggregateException = true;
+            backtraceClient.SendAsync(exception).Wait();
         }
 
         public async Task Start()
@@ -94,8 +102,8 @@ namespace Backtrace.Framework45Example
                     continue;
                 }
             }
-            //var response = await backtraceClient.SendAsync($"{DateTime.Now}: Tree generated");
-            //Console.WriteLine($"Tree generated! Backtrace object id for last message: {response.Object}");
+            var response = await backtraceClient.SendAsync($"{DateTime.Now}: Tree generated");
+            Console.WriteLine($"Tree generated! Backtrace object id for last message: {response.Object}");
         }
 
         private async Task TryClean()
@@ -135,7 +143,7 @@ namespace Backtrace.Framework45Example
 
         }
 
-        unsafe static void DividePtrParam(int* p, int* j)
+        private static unsafe void DividePtrParam(int* p, int* j)
         {
             *p = *p / *j;
         }
@@ -191,7 +199,8 @@ namespace Backtrace.Framework45Example
                    return data;
                };
         }
-        static void Main(string[] args)
+
+        private static void Main(string[] args)
         {
             Program program = new Program();
             program.Start().Wait();

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -31,18 +31,26 @@ namespace Backtrace.Framework45Example
         public Program()
         {
             SetupBacktraceLibrary();
-            var exception = new AggregateException("something really bad happend", new List<Exception>()
-            {
-                new ArgumentException("Really bad argument"),
-                new InvalidOperationException("You won't execute this line of code for sure"),
-                new FormatException("I don't have more funny exception descriptions lol"),
-                new AggregateException("Another aggregateException", new List<Exception> ()
-                {
-                    new DivideByZeroException("meh")
-                })
-            });
+            //var exception = new AggregateException("something really bad happend", new List<Exception>()
+            //{
+            //    new InvalidOperationException("You won't execute this line of code for sure"),
+            //    new ArgumentException("Really bad argument"),
+            //    new FormatException("I don't have more funny exception descriptions lol"),
+            //    new AggregateException("Another aggregateException", new List<Exception> ()
+            //    {
+            //        new DivideByZeroException("meh")
+            //    })
+            //});
+            var exception = new AggregateException("test exception",
+              new List<Exception>() {
+                     new ArgumentException("argument exception"),
+                    new InvalidOperationException("invalid operation exception"),
+                    new FormatException("format exception"),
+              });
+
+
             backtraceClient.IgnoreAggregateException = true;
-            backtraceClient.SendAsync(exception).Wait();
+            var result = backtraceClient.Send(exception);
         }
 
         public async Task Start()

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -162,7 +162,7 @@ namespace Backtrace.Framework45Example
             //setup new client
             backtraceClient = new BacktraceClient(configuartion, database)
             {
-                IgnoreAggregateException = true
+                UnpackAggregateExcetpion = true
             };
 
             //handle all unhandled application exceptions

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -35,7 +35,11 @@ namespace Backtrace.Framework45Example
             {
                 new ArgumentException("Really bad argument"),
                 new InvalidOperationException("You won't execute this line of code for sure"),
-                new FormatException("I don't have more funny exception descriptions lol")
+                new FormatException("I don't have more funny exception descriptions lol"),
+                new AggregateException("Another aggregateException", new List<Exception> ()
+                {
+                    new DivideByZeroException("meh")
+                })
             });
             backtraceClient.IgnoreAggregateException = true;
             backtraceClient.SendAsync(exception).Wait();

--- a/Examples/Backtrace.Framework45Example/Program.cs
+++ b/Examples/Backtrace.Framework45Example/Program.cs
@@ -31,23 +31,16 @@ namespace Backtrace.Framework45Example
         public Program()
         {
             SetupBacktraceLibrary();
-            //var exception = new AggregateException("something really bad happend", new List<Exception>()
-            //{
-            //    new InvalidOperationException("You won't execute this line of code for sure"),
-            //    new ArgumentException("Really bad argument"),
-            //    new FormatException("I don't have more funny exception descriptions lol"),
-            //    new AggregateException("Another aggregateException", new List<Exception> ()
-            //    {
-            //        new DivideByZeroException("meh")
-            //    })
-            //});
-            var exception = new AggregateException("test exception",
-              new List<Exception>() {
-                     new ArgumentException("argument exception"),
-                    new InvalidOperationException("invalid operation exception"),
-                    new FormatException("format exception"),
-              });
-
+            var exception = new AggregateException("something really bad happend", new List<Exception>()
+            {
+                new InvalidOperationException("You won't execute this line of code for sure"),
+                new ArgumentException("Really bad argument"),
+                new FormatException("I don't have more funny exception descriptions lol"),
+                new AggregateException("Another aggregateException", new List<Exception> ()
+                {
+                    new DivideByZeroException("meh")
+                })
+            });
 
             backtraceClient.IgnoreAggregateException = true;
             var result = backtraceClient.Send(exception);

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ For more information on `BacktraceClientConfiguration` parameters please see <a 
 
 Notes:
 - If parameter `reportPerMin` is equal to 0, there is no limit on the number of error reports per minute. When the `reportPerMin` cap is reached, `BacktraceClient.Send/BacktraceClient.SendAsync` method will return false,
-- `BacktraceClient` allows you to unpack `AggregateExceptions` and send only exceptions that are available in `InnerException` property of `AggregateException`. By default `BacktraceClient` will send `AggregateException` information to Backtrace server. To avoid sending these reports, please override `IgnoreAggregateException` and set value to `true`.
+- `BacktraceClient` allows you to unpack `AggregateExceptions` and send only exceptions that are available in `InnerException` property of `AggregateException`. By default `BacktraceClient` will send `AggregateException` information to Backtrace server. To avoid sending these reports, please override `UnpackAggregateException` and set value to `true`.
 
 
 #### Database initialization <a name="documentation-database-initialization"></a>
@@ -395,7 +395,7 @@ You can extend `BacktraceBase` to create your own Backtrace client and error rep
 `BacktraceApi` can send synchronous and asynchronous reports to the Backtrace endpoint. To enable asynchronous report (default is synchronous) you have to set `AsynchronousRequest` property to `true`.
 
 ## BacktraceResult  <a name="architecture-BacktraceResult"></a>
-**`BacktraceResult`** is a class that holds response and result from a `Send` or `SendAsync` call. The class contains a `Status` property that indicates whether the call was completed (`OK`), the call returned with an error (`ServerError`), or the call was aborted because client reporting limit was reached (`LimitReached`). Additionally, the class has a `Message` property that contains details about the status. Note that the `Send` call may produce an error report on an inner exception, in this case you can find an additional `BacktraceResult` object in the `InnerExceptionResult` property.
+**`BacktraceResult`** is a class that holds response and result from a `Send` or `SendAsync` call. The class contains a `Status` property that indicates whether the call was completed (`OK`), the call returned with an error (`ServerError`), the call was aborted because client reporting limit was reached (`LimitReached`), or the call wasn't needed because developer use `UnpackAggregateException` property with empty `AggregateException` object (`Empty`).  Additionally, the class has a `Message` property that contains details about the status. Note that the `Send` call may produce an error report on an inner exception, in this case you can find an additional `BacktraceResult` object in the `InnerExceptionResult` property.
 
 ## BacktraceDatabase  <a name="architecture-BacktraceDatabase"></a>
 **`BacktraceDatabase`** is a class that stores error report data in your local hard drive. If `DatabaseSettings` dones't contain a **valid** `DatabasePath` then `BacktraceDatabase` won't generate minidump files and store error report data. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Backtrace
-[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.3-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.4-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp)
 
-[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.4-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.5-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu/branch/dev?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp/branch/dev)
 
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Notes:
 - `BacktraceReport` allows you to change default fingerprint generation algorithm. You can use `Fingerprint` property if you want to change fingerprint value. Keep in mind - fingerprint should be valid sha256 string.,
 - `BacktraceReport` allows you to change grouping strategy in Backtrace server. If you want to change how algorithm group your reports in Backtrace server please override `Factor` property.
 
-If you want to use `Fingerprint` and `Factory` property you have to override default property values. See example below to check how to use these properties:
+If you want to use `Fingerprint` and `Factor` property you have to override default property values. See example below to check how to use these properties:
 
 ```
 try

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ For more information on `BacktraceClientConfiguration` parameters please see <a 
 
 
 Notes:
-- If parameter `reportPerMin` is equal to 0, there is no limit on the number of error reports per minute. When the `reportPerMin` cap is reached, `BacktraceClient.Send/BacktraceClient.SendAsync` method will return false.
+- If parameter `reportPerMin` is equal to 0, there is no limit on the number of error reports per minute. When the `reportPerMin` cap is reached, `BacktraceClient.Send/BacktraceClient.SendAsync` method will return false,
+- `BacktraceClient` allows you to unpack `AggregateExceptions` and send only exceptions that are available in `InnerException` property of `AggregateException`. By default `BacktraceClient` will send `AggregateException` information to Backtrace server. To avoid sending these reports, please override `IgnoreAggregateException` and set value to `true`.
 
 
 #### Database initialization <a name="documentation-database-initialization"></a>
@@ -259,7 +260,27 @@ catch (Exception exception)
 Notes:
 - if you initialize `BacktraceClient` with `BacktraceDatabase` and your application is offline or you pass invalid credentials to `BacktraceClient`, reports will be stored in database directory path,
 - for .NET 4.5+, we recommend to use `SendAsync` method,
-- if you don't want to use reflection to determine valid stack frame method name, you can pass `false` to `reflectionMethodName`. By default this value is equal to `true`.
+- if you don't want to use reflection to determine valid stack frame method name, you can pass `false` to `reflectionMethodName`. By default this value is equal to `true`,
+- `BacktraceReport` allows you to change default fingerprint generation algorithm. You can use `Fingerprint` property if you want to change fingerprint value. Keep in mind - fingerprint should be valid sha256 string.,
+- `BacktraceReport` allows you to change grouping strategy in Backtrace server. If you want to change how algorithm group your reports in Backtrace server please override `Factor` property.
+
+If you want to use `Fingerprint` and `Factory` property you have to override default property values. See example below to check how to use these properties:
+
+```
+try
+{
+  //throw exception here
+}
+catch (Exception exception)
+{
+    var report = new BacktraceReport(...){
+        FingerPrint = "sha256 string",
+        Factor = exception.GetType().Name
+    };
+    ....
+}
+
+```
 
 #### Asynchronous Send Support
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Backtrace
-[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.1-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@release](https://img.shields.io/badge/Backtrace%40master-2.0.3-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp)
 
-[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.2-blue.svg)](https://www.nuget.org/packages/Backtrace)
+[![Backtrace@pre-release](https://img.shields.io/badge/Backtrace%40dev-2.0.4-blue.svg)](https://www.nuget.org/packages/Backtrace)
 [![Build status](https://ci.appveyor.com/api/projects/status/o0n9sp0ydgxb3ktu/branch/dev?svg=true)](https://ci.appveyor.com/project/konraddysput/backtrace-csharp/branch/dev)
 
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ var dbSettings = new BacktraceDatabaseSettings("databaseDirectory"){
     AutoSendMode = true,
     RetryBehavior = Backtrace.Types.RetryBehavior.ByInterval
 };
-var database = new BacktraceDatabase<object>(dbSettings);
+var database = new BacktraceDatabase(dbSettings);
 var credentials = new BacktraceCredentials("backtrace_endpoint_url", "token");
 var configuration = new BacktraceClientConfiguration(credentials);
 var backtraceClient = new BacktraceClient(configuration, database);
@@ -313,7 +313,7 @@ catch (Exception exception)
  //Add your own handler to client API
 
 backtraceClient.BeforeSend =
-    (Model.BacktraceData<object> model) =>
+    (Model.BacktraceData model) =>
     {
         var data = model;
         //do something with data for example:        

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,3 @@ test_script:
     - ps: dotnet test .\Backtrace.Tests\
     - sh: dotnet test ./Backtrace.Tests -f netcoreapp2.0
 deploy: off
-on_finish:
-    - ps echo "Build finished successfully"
-    - sh echo "Build finished successfully"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: 
-    - Visual Studio 2017
     - Ubuntu
+    - Visual Studio 2017
 branches:
     only:
     - /master
@@ -20,7 +20,8 @@ build_script:
     - sh: dotnet build ./Backtrace/Backtrace.csproj -f netstandard2.0
 test_script:
     - ps: dotnet test .\Backtrace.Tests\
-    - sh: dotnet test ./Backtrace.Tests -f netstandard2.0
+    - sh: dotnet test ./Backtrace.Tests -f netcoreapp2.0
 deploy: off
 on_finish:
     - ps echo "Build finished successfully"
+    - sh echo "Build finished successfully"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,17 +9,18 @@ branches:
 environment:  
   APPVEYOR_YML_DISABLE_PS_LINUX: true
 init:
-  # Good practise, because Windows line endings are different from Unix/Linux ones
-    - cmd: git config --global core.autocrlf true
+    # Good practise, because Windows line endings are different from Unix/Linux ones
+    - ps: git config --global core.autocrlf true
 before_build:
     # Display .NET version
-    - cmd: dotnet --version
+    - ps: dotnet --version
 build_script:
     #solve problem for .NET 3.5 by using two build commands#
     - ps: dotnet build .\Backtrace\Backtrace.csproj -f netstandard2.0 ; dotnet build .\Backtrace\Backtrace.csproj -f net45
-    - sh: dotnet build .\Backtrace\Backtrace.csproj -f netstandard2.0
+    - sh: dotnet build ./Backtrace/Backtrace.csproj -f netstandard2.0
 test_script:
     - ps: dotnet test .\Backtrace.Tests\
+    - sh: dotnet test ./Backtrace.Tests
 deploy: off
 on_finish:
     - ps echo "Build finished successfully"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
     - sh: dotnet build ./Backtrace/Backtrace.csproj -f netstandard2.0
 test_script:
     - ps: dotnet test .\Backtrace.Tests\
-    - sh: dotnet test ./Backtrace.Tests
+    - sh: dotnet test ./Backtrace.Tests -f netstandard2.0
 deploy: off
 on_finish:
     - ps echo "Build finished successfully"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ branches:
     only:
     - /master
     - /dev
+environment:  
+  APPVEYOR_YML_DISABLE_PS_LINUX: true
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
     - cmd: git config --global core.autocrlf true
@@ -15,6 +17,7 @@ before_build:
 build_script:
     #solve problem for .NET 3.5 by using two build commands#
     - ps: dotnet build .\Backtrace\Backtrace.csproj -f netstandard2.0 ; dotnet build .\Backtrace\Backtrace.csproj -f net45
+    - sh: dotnet build .\Backtrace\Backtrace.csproj -f netstandard2.0
 test_script:
     - ps: dotnet test .\Backtrace.Tests\
 deploy: off


### PR DESCRIPTION
- `BacktraceClient` allows developer to unpack `AggregateException` and send only exceptions available in `InnerExceptions` property.
- `BacktraceReport` accepts two new properties: `Factory` and `Fingerprint`. These properties allows you to change server side algorithms. 
- `BacktraceData` now include informations about `Exception` properties. You can check detailed `Exception` properties in Annotations.
- `BacktraceDatabase` doesn't throw exception when developer can't add new record. This situation exists when database was full or database hasn't enough disk space for exceptions.
- `BacktraceResult` can use new `Status`. In case when developer want to unpack `AggregateException` and `InnerExceptions` property is empty, `BacktraceClient` return `BacktraceResult` with status `Empty`,