### PR TITLE
Fix exception stack trace

### DIFF
--- a/Backtrace/Model/BacktraceStackTrace.cs
+++ b/Backtrace/Model/BacktraceStackTrace.cs
@@ -41,8 +41,6 @@ namespace Backtrace.Model
             //initialize environment stack trace
             var stackTrace = new StackTrace(true);
             //reverse frame order
-            var frames = stackTrace.GetFrames();
-            SetStacktraceInformation(frames, generateExceptionInformation);
             if (_exception != null)
             {
                 if (CallingAssembly == null)
@@ -52,6 +50,11 @@ namespace Backtrace.Model
                 var exceptionStackTrace = new StackTrace(_exception, true);
                 var exceptionFrames = exceptionStackTrace.GetFrames();
                 SetStacktraceInformation(exceptionFrames, true);
+            }
+            else
+            {
+                var frames = stackTrace.GetFrames();
+                SetStacktraceInformation(frames, generateExceptionInformation);
             }
             //Library didn't found Calling assembly
             //The reason for this behaviour is because we throw exception from TaskScheduler


### PR DESCRIPTION
I've been noticing that in my Backtrace reports, the code that generated the report is always in the stack trace. Looking through the code, it seems like the stack that generated the report is collected and squished into the same list as the stack for the actual exception. If we have an exception stack, that's all we really care about. The other stack is virtually useless, and makes it much harder to find where the actual exception stack begins/ends. 

This change makes it so that if an exception is passed in, just the exception's stack is logged. If no exception is provided, then the calling stack is logged - in case of a non-exception error scenario that someone just wants to log where the error came from.