### PR TITLE
Version 2.0.7

### DIFF
--- a/Backtrace.Tests/ClientTests/TestExceptionLogCreation.cs
+++ b/Backtrace.Tests/ClientTests/TestExceptionLogCreation.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Backtrace.Tests.ClientTests
@@ -33,26 +34,19 @@ namespace Backtrace.Tests.ClientTests
         }
 
         [Test]
-        public void TestEnvironmentStackTrace_EnvironmentStakcTraceIsEqualToTrue_ShouldReturnCorrectStackTrace()
+        public void TestReportStackTrace_StackTraceShouldBeTheSameLikeExceptionStackTrace_ShouldReturnCorrectStackTrace()
         {
-            //this type of exception return empty stack trace
-            //in this test if exception is empty and we don't include environemnt stacktrace
-            //diagnostic stack will be empty
-            var report = new BacktraceReport(new Exception("exception"), includeEnvironmentStacktrace: true);
-            Assert.IsTrue(report.DiagnosticStack?.Any());
-        }
-        [Test]
-        public void TestEnvironmentStackTrace_DefaultStackTraceParameter_ShouldReturnCorrectStackTrace()
-        {
-            var report = new BacktraceReport(new Exception("exception"));
-            Assert.IsTrue(report.DiagnosticStack?.Any());
+            var exception = new Exception("exception");
+            var report = new BacktraceReport(exception);
+            Assert.AreEqual(report.DiagnosticStack.Count, exception.StackTrace?.Count() ?? 0);
         }
 
         [Test]
-        public void TestEnvironmentStackTrace_EnvironmentStakcTraceIsEqualToFalse_ShouldReturnCorrectStackTrace()
+        public void TestReportStackTrace_StackTraceShouldIncludeEnvironmentStackTrace_ShouldReturnCorrectStackTrace()
         {
-            var report = new BacktraceReport(new Exception("exception"), includeEnvironmentStacktrace: false);
-            Assert.IsFalse(report.DiagnosticStack?.Any());
+            var environmentStackTrace = new StackTrace(true);
+            var report = new BacktraceReport("msg");
+            Assert.AreEqual(report.DiagnosticStack.Count, environmentStackTrace.FrameCount);
         }
 
         [Test]

--- a/Backtrace.Tests/ClientTests/TestExceptionLogCreation.cs
+++ b/Backtrace.Tests/ClientTests/TestExceptionLogCreation.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Backtrace.Tests.ClientTests
 {
@@ -29,6 +30,29 @@ namespace Backtrace.Tests.ClientTests
             Assert.DoesNotThrow(() => _backtraceClient.Send(exception: exception));
             Assert.DoesNotThrow(() => _backtraceClient.Send(message: "test message"));
             Assert.DoesNotThrow(() => _backtraceClient.Send(new BacktraceReport(exception)));
+        }
+
+        [Test]
+        public void TestEnvironmentStackTrace_EnvironmentStakcTraceIsEqualToTrue_ShouldReturnCorrectStackTrace()
+        {
+            //this type of exception return empty stack trace
+            //in this test if exception is empty and we don't include environemnt stacktrace
+            //diagnostic stack will be empty
+            var report = new BacktraceReport(new Exception("exception"), includeEnvironmentStacktrace: true);
+            Assert.IsTrue(report.DiagnosticStack?.Any());
+        }
+        [Test]
+        public void TestEnvironmentStackTrace_DefaultStackTraceParameter_ShouldReturnCorrectStackTrace()
+        {
+            var report = new BacktraceReport(new Exception("exception"));
+            Assert.IsTrue(report.DiagnosticStack?.Any());
+        }
+
+        [Test]
+        public void TestEnvironmentStackTrace_EnvironmentStakcTraceIsEqualToFalse_ShouldReturnCorrectStackTrace()
+        {
+            var report = new BacktraceReport(new Exception("exception"), includeEnvironmentStacktrace: false);
+            Assert.IsFalse(report.DiagnosticStack?.Any());
         }
 
         [Test]

--- a/Backtrace.Tests/ClientTests/TestMessageLogCreation.cs
+++ b/Backtrace.Tests/ClientTests/TestMessageLogCreation.cs
@@ -1,12 +1,8 @@
-﻿using System;
+﻿using Backtrace.Model;
+using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Moq;
-using NUnit.Framework;
-using Backtrace.Interfaces;
-using Backtrace.Model;
 
 namespace Backtrace.Tests.ClientTests
 {
@@ -40,9 +36,9 @@ namespace Backtrace.Tests.ClientTests
         [Test(Author = "Konrad Dysput", Description = "Test messages with attributes")]
         public void TestMessageAttributes(string message)
         {
-            Dictionary<string, object> currentAttributes = new Dictionary<string, object>();
+            var currentAttributes = new Dictionary<string, object>();
             _backtraceClient.BeforeSend =
-                (Model.BacktraceData model) =>
+                (BacktraceData model) =>
                 {
                     currentAttributes = model.Attributes;
                     return model;

--- a/Backtrace/Backtrace.csproj
+++ b/Backtrace/Backtrace.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net45;net35</TargetFrameworks>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</PackageTags>
-    <PackageVersion>2.0.6</PackageVersion>
+    <PackageVersion>2.0.7</PackageVersion>
     <Product>Backtrace</Product>
     <PackageLicenseUrl>https://github.com/backtrace-labs/backtrace-csharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/backtrace-labs/backtrace-csharp</PackageProjectUrl>
@@ -12,12 +12,12 @@
     <Description>Backtrace's integration with C# applications allows customers to capture and report handled and unhandled C# exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.</Description>
     <RepositoryUrl>https://github.com/backtrace-labs/backtrace-csharp</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
     <Copyright>Backtrace I/O</Copyright>
     <Authors>Backtrace I/O</Authors>
     <Company>Backtrace I/O</Company>
-    <AssemblyVersion>2.0.6.0</AssemblyVersion>
-    <FileVersion>2.0.6.0</FileVersion>
+    <AssemblyVersion>2.0.7.0</AssemblyVersion>
+    <FileVersion>2.0.7.0</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Backtrace/Base/BacktraceBase.cs
+++ b/Backtrace/Base/BacktraceBase.cs
@@ -102,6 +102,7 @@ namespace Backtrace.Base
         /// </summary>
         public readonly Dictionary<string, object> Attributes;
 
+
         /// <summary>
         /// Backtrace database instance that allows to manage minidump files 
         /// </summary>

--- a/Backtrace/Model/BacktraceCredentials.cs
+++ b/Backtrace/Model/BacktraceCredentials.cs
@@ -177,8 +177,7 @@ namespace Backtrace.Model
             {
                 throw new ArgumentException($"Section {nameof(sectionName)} is null or empty");
             }
-            var applicationSettings = ConfigurationManager.GetSection(sectionName) as NameValueCollection;
-            if (applicationSettings == null || applicationSettings.Count == 0)
+            if (!(ConfigurationManager.GetSection(sectionName) is NameValueCollection applicationSettings) || applicationSettings.Count == 0)
             {
                 throw new InvalidOperationException("Application setting are not defined");
             }

--- a/Backtrace/Model/BacktraceReport.cs
+++ b/Backtrace/Model/BacktraceReport.cs
@@ -85,13 +85,7 @@ namespace Backtrace.Model
         /// </summary>
         [JsonProperty(PropertyName = "minidumpFile")]
         internal string MinidumpFile { get; private set; }
-
-        /// <summary>
-        /// Include environment stack trace when sending exception report to Backtrace
-        /// </summary>
-        [JsonProperty(PropertyName = "environmentStackTrace")]
-        public bool IncludeEnvironmentStackTrace { get; private set; }
-
+        
         /// <summary>
         /// Get an assembly where report was created (or should be created)
         /// </summary>
@@ -111,7 +105,7 @@ namespace Backtrace.Model
             Dictionary<string, object> attributes = null,
             List<string> attachmentPaths = null,
             bool reflectionMethodName = true)
-            : this(null as Exception, attributes, attachmentPaths, reflectionMethodName, true)
+            : this(null as Exception, attributes, attachmentPaths, reflectionMethodName)
         {
             Message = message;
         }
@@ -127,8 +121,7 @@ namespace Backtrace.Model
             Exception exception,
             Dictionary<string, object> attributes = null,
             List<string> attachmentPaths = null,
-            bool reflectionMethodName = true,
-            bool includeEnvironmentStacktrace = true)
+            bool reflectionMethodName = true)
         {
             Attributes = attributes ?? new Dictionary<string, object>();
             AttachmentPaths = attachmentPaths ?? new List<string>();
@@ -136,7 +129,6 @@ namespace Backtrace.Model
             ExceptionTypeReport = exception != null;
             Classifier = ExceptionTypeReport ? exception.GetType().Name : string.Empty;
             _reflectionMethodName = reflectionMethodName;
-            IncludeEnvironmentStackTrace = includeEnvironmentStacktrace;
             SetCallingAssemblyInformation();
         }
 
@@ -178,7 +170,7 @@ namespace Backtrace.Model
 
         internal void SetCallingAssemblyInformation()
         {
-            var stacktrace = new BacktraceStackTrace(Exception, _reflectionMethodName, IncludeEnvironmentStackTrace);
+            var stacktrace = new BacktraceStackTrace(Exception, _reflectionMethodName);
             DiagnosticStack = stacktrace.StackFrames;
             CallingAssembly = stacktrace.CallingAssembly;
         }

--- a/Backtrace/Model/BacktraceStackTrace.cs
+++ b/Backtrace/Model/BacktraceStackTrace.cs
@@ -21,19 +21,13 @@ namespace Backtrace.Model
         internal Assembly CallingAssembly { get; set; }
 
         /// <summary>
-        /// Include environment stack trace in exception reports
-        /// </summary>
-        private readonly bool _includeEnvironmentStackTrace;
-
-        /// <summary>
         /// Current exception
         /// </summary>
         private readonly Exception _exception;
         private readonly bool _reflectionMethodName;
-        public BacktraceStackTrace(Exception exception, bool reflectionMethodName, bool includeEnvironmentStackTrace)
+        public BacktraceStackTrace(Exception exception, bool reflectionMethodName)
         {
             _exception = exception;
-            _includeEnvironmentStackTrace = includeEnvironmentStackTrace;
             _reflectionMethodName = reflectionMethodName;
             Initialize();
         }
@@ -41,15 +35,7 @@ namespace Backtrace.Model
         private void Initialize()
         {
             bool generateExceptionInformation = _exception != null;
-            //initialize environment stack trace
             var stackTrace = new StackTrace(true);
-
-            if (_exception == null || _includeEnvironmentStackTrace)
-            {
-                //reverse frame order
-                var frames = stackTrace.GetFrames();
-                SetStacktraceInformation(frames, generateExceptionInformation);
-            }
             if (_exception != null)
             {
                 if (CallingAssembly == null)
@@ -59,6 +45,12 @@ namespace Backtrace.Model
                 var exceptionStackTrace = new StackTrace(_exception, true);
                 var exceptionFrames = exceptionStackTrace.GetFrames();
                 SetStacktraceInformation(exceptionFrames, true);
+            }
+            else
+            {
+                //reverse frame order
+                var frames = stackTrace.GetFrames();
+                SetStacktraceInformation(frames, generateExceptionInformation);
             }
             //Library didn't found Calling assembly
             //The reason for this behaviour is because we throw exception from TaskScheduler

--- a/Backtrace/Model/BacktraceStackTrace.cs
+++ b/Backtrace/Model/BacktraceStackTrace.cs
@@ -1,11 +1,8 @@
 ﻿using Backtrace.Common;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 
 namespace Backtrace.Model
 {
@@ -24,13 +21,19 @@ namespace Backtrace.Model
         internal Assembly CallingAssembly { get; set; }
 
         /// <summary>
+        /// Include environment stack trace in exception reports
+        /// </summary>
+        private readonly bool _includeEnvironmentStackTrace;
+
+        /// <summary>
         /// Current exception
         /// </summary>
         private readonly Exception _exception;
         private readonly bool _reflectionMethodName;
-        public BacktraceStackTrace(Exception exception, bool reflectionMethodName)
+        public BacktraceStackTrace(Exception exception, bool reflectionMethodName, bool includeEnvironmentStackTrace)
         {
             _exception = exception;
+            _includeEnvironmentStackTrace = includeEnvironmentStackTrace;
             _reflectionMethodName = reflectionMethodName;
             Initialize();
         }
@@ -40,9 +43,13 @@ namespace Backtrace.Model
             bool generateExceptionInformation = _exception != null;
             //initialize environment stack trace
             var stackTrace = new StackTrace(true);
-            //reverse frame order
-            var frames = stackTrace.GetFrames();
-            SetStacktraceInformation(frames, generateExceptionInformation);
+
+            if (_exception == null || _includeEnvironmentStackTrace)
+            {
+                //reverse frame order
+                var frames = stackTrace.GetFrames();
+                SetStacktraceInformation(frames, generateExceptionInformation);
+            }
             if (_exception != null)
             {
                 if (CallingAssembly == null)

--- a/Backtrace/Services/BacktraceDatabaseContext.cs
+++ b/Backtrace/Services/BacktraceDatabaseContext.cs
@@ -308,7 +308,11 @@ namespace Backtrace.Services
                 //and return file
                 if (BatchRetry.ContainsKey(i) && BatchRetry[i].Any(n => !n.Locked))
                 {
-                    var record = BatchRetry[i].First(n => !n.Locked);
+                    var record = BatchRetry[i].FirstOrDefault(n => !n.Locked);
+                    if(record == null)
+                    {
+                        return null;
+                    }
                     record.Locked = true;
                     return record;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ﻿# Backtrace C# Release Notes
 
+## Version 2.0.7 - 11.02.2019
+- BacktraceReport `includeEnvironmentStacktrace` constructor parameter. If parameter is equal to `false`, then `BacktraceReport` won't have environment stack frames. Default is `true`,
+- Unit tests fix - incrementation fix,
+- `BacktraceDatabase` fix for `FirstOrDefault` invalid read.
+
 ## Version 2.0.6 - 20.12.2018
 - New `BacktraceCredentials` constructor,
 - UnhandledThreadException flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ﻿# Backtrace C# Release Notes
 
 ## Version 2.0.7 - 11.02.2019
-- BacktraceReport `includeEnvironmentStacktrace` constructor parameter. If parameter is equal to `false`, then `BacktraceReport` won't have environment stack frames. Default is `true`,
+- If you send exception, `BacktraceReport` will generate stack trace based on exception stack trace. We will no longer include environment stack trace in exception reports,
 - Unit tests fix - incrementation fix,
 - `BacktraceDatabase` fix for `FirstOrDefault` invalid read.
 

--- a/Examples/Backtrace.Core/ApplicationSettings.cs
+++ b/Examples/Backtrace.Core/ApplicationSettings.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Backtrace.Core
+﻿namespace Backtrace.Core
 {
     public static class ApplicationSettings
     {
-        public const string Host = @"https://myserver.sp.backtrace.io:6097";
-        public const string Token = "4dca18e8769d0f5d10db0d1b665e64b3d716f76bf182fbcdad5d1d8070c12db0";
-        public const string DatabasePath = "";
+        public const string Host = @"http://yolo.sp.backtrace.io:6097/";
+        public const string Token = "328174ab5c377e2cdcb6c763ec2bbdf1f9aa5282c1f6bede693efe06a479db54";
+        public const string DatabasePath = @"C:\Users\konra\source\database";
     }
 }

--- a/Examples/Backtrace.Core/ApplicationSettings.cs
+++ b/Examples/Backtrace.Core/ApplicationSettings.cs
@@ -2,8 +2,8 @@
 {
     public static class ApplicationSettings
     {
-        public const string Host = @"http://yolo.sp.backtrace.io:6097/";
-        public const string Token = "328174ab5c377e2cdcb6c763ec2bbdf1f9aa5282c1f6bede693efe06a479db54";
-        public const string DatabasePath = @"C:\Users\konra\source\database";
+        public const string Host = @"https://myserver.sp.backtrace.io:6097";
+        public const string Token = "4dca18e8769d0f5d10db0d1b665e64b3d716f76bf182fbcdad5d1d8070c12db0";
+        public const string DatabasePath = "";
     }
 }

--- a/Examples/Backtrace.Core/Backtrace.Core.csproj
+++ b/Examples/Backtrace.Core/Backtrace.Core.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Examples/Backtrace.Core/Program.cs
+++ b/Examples/Backtrace.Core/Program.cs
@@ -1,19 +1,18 @@
 ﻿using Backtrace.Core.Model;
-using Backtrace.Interfaces;
 using Backtrace.Model;
 using Backtrace.Model.Database;
-using Backtrace.Services;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Backtrace.Core
 {
-    class Program
+    public class Program
     {
         private Tree tree;
+
+        private readonly Random random = new Random();
 
         /// <summary>
         /// Credentials
@@ -58,7 +57,7 @@ namespace Backtrace.Core
 
         private string GetRandomString(int length)
         {
-            Random random = new Random();
+
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
             var tempString = Enumerable.Repeat(chars, length)
               .Select(s => s[random.Next(s.Length)]).ToArray();
@@ -67,7 +66,6 @@ namespace Backtrace.Core
 
         private async Task GenerateRandomStrings()
         {
-            Random random = new Random();
             int totalStrings = random.Next(20, 25);
             //+3 because we want to add two duplicats
             string[] randomStrings = new string[totalStrings + 3];
@@ -104,7 +102,6 @@ namespace Backtrace.Core
         {
             var orderedWords = tree.ToList();
             int total = orderedWords.Count();
-            Random random = new Random();
             for (int i = 0; i < 3; i++)
             {
                 int randomDuplicateIndex = random.Next(0, total);
@@ -138,7 +135,7 @@ namespace Backtrace.Core
 
         }
 
-        unsafe static void DividePtrParam(int* p, int* j)
+        private static unsafe void DividePtrParam(int* p, int* j)
         {
             *p = *p / *j;
         }
@@ -195,10 +192,10 @@ namespace Backtrace.Core
                };
         }
 
-        static void Main(string[] args)
+        private static async Task Main(string[] args)
         {
-            Program program = new Program();
-            program.Start().Wait();
+            var program = new Program();
+            await program.Start();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -215,25 +215,6 @@ Notes:
 - If a valid `databaseDirectory` directory is supplied, the Backtrace library will generate and attach a minidump to each error report automatically. Otherwise, `BacktraceDatabase` will be disabled,
 - You can set `backtraceClient.MiniDumpType` to `MiniDumpType.None` if you don't want to generate minidump files.
 
-
-#### TLS/SSL Support
-
-For .NET Standard 2.0 and .NET Framework 4.6+, TLS 1.2 support is built-in.
-
-For .NET Framework 4.5 (and below) as well as .NET Standard 2.0 (and below), TLS 1.2 support may not be available, therefore **we recommend submitting errors using the plain HTTP listener URL**. But if you wish to use lower versions of TLS/SSL, you can use still enable lower TLS/SSL support by adding the following code **before** `BacktraceClient` initialization.
-
-```csharp
-ServicePointManager.SecurityProtocol =
-                     SecurityProtocolType.Tls
-                    | (SecurityProtocolType)0x00000300
-                    | (SecurityProtocolType)0x00000C00;
-
-ServicePointManager.ServerCertificateValidationCallback 
-    += (sender, certificate, chain, errors) => true;
-```
-
-
-
 ## Sending an error report <a name="documentation-sending-report"></a>
 
 `BacktraceClient.Send/BacktraceClient.SendAsync` method will send an error report to the Backtrace endpoint specified. There `Send` method is overloaded, see examples below:

--- a/README.md
+++ b/README.md
@@ -261,8 +261,9 @@ Notes:
 - if you initialize `BacktraceClient` with `BacktraceDatabase` and your application is offline or you pass invalid credentials to `BacktraceClient`, reports will be stored in database directory path,
 - for .NET 4.5+, we recommend to use `SendAsync` method,
 - if you don't want to use reflection to determine valid stack frame method name, you can pass `false` to `reflectionMethodName`. By default this value is equal to `true`,
-- `BacktraceReport` allows you to change default fingerprint generation algorithm. You can use `Fingerprint` property if you want to change fingerprint value. Keep in mind - fingerprint should be valid sha256 string.,
-- `BacktraceReport` allows you to change grouping strategy in Backtrace server. If you want to change how algorithm group your reports in Backtrace server please override `Factor` property.
+- `BacktraceReport` allows you to change default fingerprint generation algorithm. You can use `Fingerprint` property if you want to change fingerprint value. Keep in mind - fingerprint should be valid sha256 string,
+- `BacktraceReport` allows you to change grouping strategy in Backtrace server. If you want to change how algorithm group your reports in Backtrace server please override `Factor` property,
+- By default `BacktraceReport` include to exception information environment stack trace. If you want to change this behavior please use `includeEnvironmentStacktrace` parameter in `BacktraceReport` constructor. When `includeEnvironmentStacktrace` is `false` then report will only store information about exception stack trace.
 
 If you want to use `Fingerprint` and `Factor` property you have to override default property values. See example below to check how to use these properties:
 


### PR DESCRIPTION

## Version 2.0.7 - 11.02.2019
- BacktraceReport `includeEnvironmentStacktrace` constructor parameter. If parameter is equal to `false`, then `BacktraceReport` won't have environment stack frames. Default is `true`,
- Unit tests fix - incrementation fix,
- `BacktraceDatabase` fix for `FirstOrDefault` invalid read.