### PR TITLE
Fixed LoadReports throwing NullReferenceException when invalid JSON found

### DIFF
--- a/Backtrace/BacktraceDatabase.cs
+++ b/Backtrace/BacktraceDatabase.cs
@@ -371,6 +371,8 @@ namespace Backtrace
             foreach (var file in files)
             {
                 var record = BacktraceDatabaseRecord.ReadFromFile(file);
+                if (record == null)
+                    continue;
                 record.DatabasePath(DatabasePath);
                 if (!record.Valid())
                 {


### PR DESCRIPTION
https://github.com/backtrace-labs/backtrace-csharp/issues/25