### PR TITLE
Recover .NET Framework 4.5 checks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,10 +16,7 @@ jobs:
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            3.0.x
-            5.0.x
-            8.0.x
+          dotnet-version: 3.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release
 
       - name: Run tests
-        run: dotnet test Backtrace.Tests -f net45
+        run: dotnet test Backtrace.Tests
 
   test_dotnet80:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 4.5.0
+          dotnet-version: 4.5.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,26 +1,49 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+name: .NET Tests
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - main
   pull_request:
 
 jobs:
-  build:
+  test_dotnet45:
     runs-on: windows-latest
-
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET Framework 4.5
+        run: |
+          choco install visualstudio2017-workload-netfx
+          choco install netfx-4.5.2-devpack
+
+      - name: Restore dependencies
+        run: nuget restore
+
+      - name: Build solution
+        run: msbuild /p:Configuration=Release .\Backtrace\Backtrace.csproj
+
+      - name: Run tests
+        run: |
+          vstest.console.exe Backtrace.Tests
+
+  test_dotnet80:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 8.0.x
+
       - name: Restore dependencies
         run: dotnet restore
-      - name: Build
-        run: dotnet build .\Backtrace\Backtrace.csproj --no-restore
-      - name: Test
-        run: dotnet test Backtrace.Tests --verbosity normal
+
+      - name: Build solution
+        run: dotnet build .\Backtrace\Backtrace.csproj --no-restore --configuration Release
+
+      - name: Run tests
+        run: dotnet test Backtrace.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 4.5.0
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           dotnet-version: 3.0.x
 
+      - name: Verify fomatting
+        run: dotnet format '.' --verify-no-changes
+
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-       - name: Setup .NET 8.0
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             3.0.x
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,15 +13,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup .NET Framework 4.5
+      - name: Setup .NET Framework 4.5 and MSBuild
         run: |
-          choco install visualstudio2017-workload-netfx
-          choco install netfx-4.5.2-devpack
-          echo "Installing MSBuild tools..."
-          choco install microsoft-build-tools -y
+          echo "Installing .NET Framework 4.8 Developer Pack..."
+          choco install netfx-4.8-devpack -y
+
+          echo "Installing Visual Studio 2019 Build Tools..."
+          choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools --includeRecommended --includeOptional" -y
+
+          echo "Adding MSBuild to PATH..."
+          $env:PATH += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\"
+          Write-Output $env:PATH
+
           echo "Verifying MSBuild installation..."
-          $msbuild = Get-Command msbuild
-          Write-Output "MSBuild is installed at $msbuild"
+          if (!(Get-Command msbuild -ErrorAction SilentlyContinue)) {
+            Write-Error "MSBuild is not installed or not in the PATH."
+            exit 1
+          } else {
+            Write-Output "MSBuild is installed and available."
+          }
 
       - name: Restore dependencies
         run: nuget restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           dotnet-version: 3.0.x
 
-      - name: Verify fomatting
-        run: dotnet format '.' --verify-no-changes
-
       - name: Restore dependencies
         run: dotnet restore
+
+      - name: Verify fomatting
+        run: dotnet format '.' --verify-no-changes
 
       - name: Build solution
         run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "4.5.x"
+          dotnet-version: 5.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test_dotnet45:
+  test_windows:
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -25,9 +25,9 @@ jobs:
         run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release
 
       - name: Run tests
-        run: dotnet test Backtrace.Tests
+        run: dotnet test Backtrace.Tests --verbosity normal
 
-  test_dotnet80:
+  test_linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -45,4 +45,4 @@ jobs:
         run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release
 
       - name: Run tests
-        run: dotnet test Backtrace.Tests
+        run: dotnet test Backtrace.Tests --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            3.0.x
+            5.0.x
+            8.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,35 +13,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup .NET Framework 4.5 and MSBuild
-        run: |
-          echo "Installing .NET Framework 4.8 Developer Pack..."
-          choco install netfx-4.8-devpack -y
-
-          echo "Installing Visual Studio 2019 Build Tools..."
-          choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools --includeRecommended --includeOptional" -y
-
-          echo "Adding MSBuild to PATH..."
-          $env:PATH += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\"
-          Write-Output $env:PATH
-
-          echo "Verifying MSBuild installation..."
-          if (!(Get-Command msbuild -ErrorAction SilentlyContinue)) {
-            Write-Error "MSBuild is not installed or not in the PATH."
-            exit 1
-          } else {
-            Write-Output "MSBuild is installed and available."
-          }
+       - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
 
       - name: Restore dependencies
-        run: nuget restore
+        run: dotnet restore
 
       - name: Build solution
-        run: msbuild /p:Configuration=Release .\Backtrace\Backtrace.csproj
+        run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release
 
       - name: Run tests
-        run: |
-          vstest.console.exe Backtrace.Tests
+        run: dotnet test Backtrace.Tests -f net45
 
   test_dotnet80:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,6 +17,11 @@ jobs:
         run: |
           choco install visualstudio2017-workload-netfx
           choco install netfx-4.5.2-devpack
+          echo "Installing MSBuild tools..."
+          choco install microsoft-build-tools -y
+          echo "Verifying MSBuild installation..."
+          $msbuild = Get-Command msbuild
+          Write-Output "MSBuild is installed at $msbuild"
 
       - name: Restore dependencies
         run: nuget restore
@@ -43,7 +48,7 @@ jobs:
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build .\Backtrace\Backtrace.csproj --no-restore --configuration Release
+        run: dotnet build ./Backtrace/Backtrace.csproj --no-restore --configuration Release
 
       - name: Run tests
         run: dotnet test Backtrace.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 4.5.x
+          dotnet-version: "4.5.x"
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.0.x

--- a/Backtrace.Tests/Backtrace.Tests.csproj
+++ b/Backtrace.Tests/Backtrace.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net80</TargetFrameworks>
+    <TargetFrameworks>net45;net80</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Backtrace.Tests/Backtrace.Tests.csproj
+++ b/Backtrace.Tests/Backtrace.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net80</TargetFrameworks>
+    <TargetFrameworks>net45;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Backtrace.Tests/Backtrace.Tests.csproj
+++ b/Backtrace.Tests/Backtrace.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net80</TargetFrameworks>
+    <TargetFrameworks>net45;net50</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Backtrace.Tests/Backtrace.Tests.csproj
+++ b/Backtrace.Tests/Backtrace.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net50</TargetFrameworks>
+    <TargetFrameworks>net45;net80</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Backtrace\Backtrace.csproj" />

--- a/Backtrace.Tests/ClientTests/TestClientCredentials.cs
+++ b/Backtrace.Tests/ClientTests/TestClientCredentials.cs
@@ -10,7 +10,7 @@ namespace Backtrace.Tests.ClientTests
     public class TestClientCredentials
     {
 
-#if NET35 || NET48
+#if NET35 || NET45
         [TestCase("EmptyCredentials")]
         [Test(Author = "Konrad Dysput", Description = "Test empty values in configuration section")]
         public void TestInvalidSectionName(string sectionName)
@@ -99,7 +99,7 @@ namespace Backtrace.Tests.ClientTests
             //if programmer pass invalid url should throw UriFormatException
             //if programmer pass null or empty string as token should throw ArgumentNullException
 
-#if NET35 || NET48
+#if NET35 || NET45
             Assert.Throws<UriFormatException>(() => new BacktraceClient(sectionName));
 #endif
             Assert.Throws<ArgumentException>(() => new BacktraceClient(new BacktraceCredentials("https://test.backtrace.io", string.Empty)));

--- a/Backtrace/Backtrace.csproj
+++ b/Backtrace/Backtrace.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Backtrace</PackageId>
     <Title>Backtrace</Title>
-    <TargetFrameworks>netstandard2.0;net35;NET48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net35;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</PackageTags>
     <tags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</tags>
@@ -31,13 +31,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="Microsoft.Diagnostics.Runtime">
       <Version>0.9.170809.3</Version>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET48'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/Backtrace/Model/BacktraceCredentials.cs
+++ b/Backtrace/Model/BacktraceCredentials.cs
@@ -168,7 +168,7 @@ namespace Backtrace.Model
             return token != null && token.Length > 0 && uri.IsWellFormedOriginalString();
         }
 
-#if NET35 || NET48
+#if NET35 || NET45
         /// <summary>
         /// Read Backtrace credentials from application configuration
         /// </summary>

--- a/Backtrace/Model/BacktraceStackFrame.cs
+++ b/Backtrace/Model/BacktraceStackFrame.cs
@@ -66,7 +66,7 @@ namespace Backtrace.Model
 
         internal Assembly FrameAssembly { get; set; }
 
-#if NET48
+#if NET45
         public BacktraceStackFrame(Microsoft.Diagnostics.Runtime.ClrStackFrame frame)
         {
             FunctionName = frame.Method.Name;

--- a/Backtrace/Model/JsonData/ThreadData.cs
+++ b/Backtrace/Model/JsonData/ThreadData.cs
@@ -1,4 +1,4 @@
-﻿#if NET48
+﻿#if NET45
 using Microsoft.Diagnostics.Runtime;
 #endif
 using Backtrace.Extensions;
@@ -31,7 +31,7 @@ namespace Backtrace.Model.JsonData
         /// </summary>
         internal ThreadData(Assembly callingAssembly, IEnumerable<BacktraceStackFrame> exceptionStack)
         {
-#if NET48
+#if NET45
             try
             {
                 //use available in .NET 4.5 api to find stack trace of all available managed threads
@@ -97,7 +97,7 @@ namespace Backtrace.Model.JsonData
             }
         }
 
-#if NET48
+#if NET45
         /// <summary>
         /// Get all used threads in calling assembly. Function ignore current thread Id 
         /// </summary>

--- a/Examples/Backtrace.FrameworkExample/ApplicationSettings.cs
+++ b/Examples/Backtrace.FrameworkExample/ApplicationSettings.cs
@@ -2,7 +2,7 @@
 {
     public static class ApplicationSettings
     {
-        public const string SubmissionUrl = "https://submit.backtrace.io/{universe}/{token}/json";
+        public const string SubmissionUrl = "https://submit.backtrace.io/yolo/d5ea4541c2babfcdf6da55d48ee3dbe98af2567899feba1155be551878423e57/json";
         public const string DatabasePath = "";
     }
 }

--- a/Examples/Backtrace.FrameworkExample/ApplicationSettings.cs
+++ b/Examples/Backtrace.FrameworkExample/ApplicationSettings.cs
@@ -2,7 +2,7 @@
 {
     public static class ApplicationSettings
     {
-        public const string SubmissionUrl = "https://submit.backtrace.io/yolo/d5ea4541c2babfcdf6da55d48ee3dbe98af2567899feba1155be551878423e57/json";
+        public const string SubmissionUrl = "https://submit.backtrace.io/{universe}/{token}/json";
         public const string DatabasePath = "";
     }
 }


### PR DESCRIPTION
# Why

This diff recovers preprocesor directives for .net framework 4.5, so we don't introduce any breaking change during the update

ref: BT-3038