### PR TITLE
Catch process.TotalProcessorTime  exception

### DIFF
--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -246,7 +246,7 @@ namespace Backtrace.Model.JsonData
             {
                 Trace.TraceWarning($"Cannot retrieve process age - TotalProcessorTime is not supported");
             }
-            
+
             try
             {            
                 Attributes["cpu.process.count"] = Process.GetProcesses().Count();

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -232,15 +232,16 @@ namespace Backtrace.Model.JsonData
             {
                 return;
             }
-            //How long the application has been running  in secounds
-            var processAge = Math.Round(process.TotalProcessorTime.TotalSeconds);
-            var totalProcessAge = unchecked((long)processAge);
-            if (totalProcessAge > 0)
-            {
-                Attributes["process.age"] = totalProcessAge;
-            }
             try
             {
+                //How long the application has been running  in secounds
+                var processAge = Math.Round(process.TotalProcessorTime.TotalSeconds);
+                var totalProcessAge = unchecked((long)processAge);
+                if (totalProcessAge > 0)
+                {
+                    Attributes["process.age"] = totalProcessAge;
+                }
+            
                 Attributes["cpu.process.count"] = Process.GetProcesses().Count();
 
                 //Resident memory usage.
@@ -275,7 +276,7 @@ namespace Backtrace.Model.JsonData
                     Attributes["vm.vma.peak"] = peakVirtualMemorySize;
                 }
             }
-            catch (PlatformNotSupportedException)
+            catch (NotSupportedException)
             {
                 Trace.TraceWarning($"Cannot retrieve information about process memory - platform not supported");
             }

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -248,7 +248,7 @@ namespace Backtrace.Model.JsonData
             }
 
             try
-            {            
+            {
                 Attributes["cpu.process.count"] = Process.GetProcesses().Count();
 
                 //Resident memory usage.

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -241,7 +241,14 @@ namespace Backtrace.Model.JsonData
                 {
                     Attributes["process.age"] = totalProcessAge;
                 }
+            }
+            catch (NotSupportedException)
+            {
+                Trace.TraceWarning($"Cannot retrieve process age - TotalProcessorTime is not supported");
+            }
             
+            try
+            {            
                 Attributes["cpu.process.count"] = Process.GetProcesses().Count();
 
                 //Resident memory usage.


### PR DESCRIPTION
process.TotalProcessorTime is not supported on all platforms
![image](https://github.com/user-attachments/assets/679983ec-7106-45f5-a894-5e343aef8db3)
