### PR TITLE
Release 2.1.11

### DIFF
--- a/Backtrace/Backtrace.csproj
+++ b/Backtrace/Backtrace.csproj
@@ -6,7 +6,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</PackageTags>
     <tags>Backtrace Error Diagnostic Tools Debug Bug Bugs StackTrace</tags>
-    <PackageVersion>2.1.10</PackageVersion>
+    <PackageVersion>2.1.11</PackageVersion>
     <Product>Backtrace</Product>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <projectUrl>https://github.com/backtrace-labs/backtrace-csharp</projectUrl>
@@ -18,14 +18,14 @@
     <Summary>Backtrace's integration with C# app allows customers to catch and report handled and unhandled C# exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug errors.</Summary>
     <RepositoryUrl>https://github.com/backtrace-labs/backtrace-csharp</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.1.10</Version>
+    <Version>2.1.11</Version>
     <PackageLanguage>en-US</PackageLanguage>
     <Copyright>Backtrace I/O</Copyright>
     <Authors>Backtrace I/O</Authors>
     <Owners>Backtrace I/O</Owners>
     <Company>Backtrace I/O</Company>
-    <AssemblyVersion>2.1.10.0</AssemblyVersion>
-    <FileVersion>2.1.10.0</FileVersion>
+    <AssemblyVersion>2.1.11.0</AssemblyVersion>
+    <FileVersion>2.1.11.0</FileVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ﻿# Backtrace C# Release Notes
 
+## Version 2.1.11 - 26.09.2024
+
+Bugfix:
+- Fixed an Exception due to unsupported `process.TotalProcessorTime` usage (#44).
+
 ## Version 2.1.10 - 02.07.2024
 
 Improvements:
+
 - Updated dependencies to the latest verison.
 - On uncaught exception, store a report in the database rather sending it to API. If the database is not available, try sending a report to the server (#36).
 - Added `application.session`, `application.version`, `backtrace.agent` and `backtrace.version` attributes.
@@ -10,9 +16,9 @@ Improvements:
 - Added support for the `error.type` attribute (#42).
 - Fixed the problem when the `guid` attribute value was set incorrectly (#43).
 
+Maintenance:
 
-Maintenance: 
-- Removed codeql-analysis action 
+- Removed codeql-analysis action
 - Moved testing and building to Github action (#37, #40)
 - Added a CICD pipeline for releasing a new version of libraries
 


### PR DESCRIPTION
# Why

This pull request updates backtrace-csharp to the 2.1.11