### PR TITLE
Fix GetAllNetworkInterfaces exception failure

### DIFF
--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -189,7 +189,9 @@ namespace Backtrace.Model.JsonData
                             && !string.IsNullOrEmpty(n.GetPhysicalAddress()?.ToString())
                         );
             }
-            catch (Exception){}
+            catch (Exception ex){
+                Trace.TraceWarning("Failed to retrieve Network Interfaces", ex);
+            }
 
 
             if (networkInterface == null)

--- a/Backtrace/Model/JsonData/BacktraceAttributes.cs
+++ b/Backtrace/Model/JsonData/BacktraceAttributes.cs
@@ -179,12 +179,18 @@ namespace Backtrace.Model.JsonData
             {
                 return guid;
             }
-            var networkInterface =
-                 NetworkInterface.GetAllNetworkInterfaces()
-                    .FirstOrDefault(n =>
-                        n.OperationalStatus == OperationalStatus.Up
-                        && !string.IsNullOrEmpty(n.GetPhysicalAddress()?.ToString())
-                    );
+
+            NetworkInterface networkInterface = null;
+            try
+            {
+                networkInterface = NetworkInterface.GetAllNetworkInterfaces()
+                        .FirstOrDefault(n =>
+                            n.OperationalStatus == OperationalStatus.Up
+                            && !string.IsNullOrEmpty(n.GetPhysicalAddress()?.ToString())
+                        );
+            }
+            catch (Exception){}
+
 
             if (networkInterface == null)
             {


### PR DESCRIPTION
GetAllNetworkInterfaces can throw an exception (common on non-Windows platforms) which causes the entire submission to fail.
Captures any exceptions and falls back to guid.

Example failure on Linux:

```
at System.ThrowHelper.ThrowArgumentOutOfRangeException(System.ExceptionArgument, System.ExceptionResource)
at System.Globalization.CompareInfo.LastIndexOf(System.String, System.String, Int32, Int32, System.Globalization.CompareOptions)
at System.String.LastIndexOf(System.String, Int32, Int32, System.StringComparison)
at System.Net.NetworkInformation.StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile(System.String)
at System.Net.NetworkInformation.LinuxIPInterfaceProperties..ctor(System.Net.NetworkInformation.LinuxNetworkInterface, LinuxNetworkInterfaceSystemProperties)
at System.Net.NetworkInformation.LinuxNetworkInterface.GetLinuxNetworkInterfaces()
at Backtrace.Model.JsonData.BacktraceAttributes.GenerateMachineId()
```
